### PR TITLE
Elysia Collective dry-run harness

### DIFF
--- a/elysia_collective_seed/DRY_RUN.md
+++ b/elysia_collective_seed/DRY_RUN.md
@@ -1,0 +1,50 @@
+# Elysia Collective 0.1 Dry Run
+
+This dry run validates the collective protocol without invoking any model, browser, credential, Guardian runtime capability, mutation system, or external action.
+
+## Purpose
+
+Before real agents are connected, prove that the proposed social/cognitive machinery has basic internal coherence:
+
+- packet IDs are unique
+- parent lineage only points backward to existing packets
+- confidence remains bounded from 0 to 1
+- routing is driven by explicit `needs`
+- Erebus critique becomes a new packet rather than mutating source history
+- Engineer proposals preserve their ancestry
+- Elysia synthesis cites the chain it integrates
+
+## Simulated EC-001 lineage
+
+1. Explorer proposes a three-tier/provenance memory principle.
+2. Researcher contributes supporting evidence.
+3. Erebus identifies recursive-summary drift as a failure mode.
+4. Engineer converts the surviving idea into an implementation proposal.
+5. Erebus reviews the implementation conditions.
+6. Elysia creates a parent-linked synthesis representing the current collective position.
+
+The content is deliberately deterministic. The goal is protocol verification, not intelligence evaluation.
+
+## Run
+
+From the repository root:
+
+```bash
+python -m elysia_collective_seed.dry_run_harness
+```
+
+Tests:
+
+```bash
+pytest -q elysia_collective_seed/test_dry_run.py
+```
+
+## Expected properties
+
+A successful run must not require network access or API keys. It should print the packet lineage and each packet's next routing destination. Tests should fail if lineage references a future/nonexistent packet or if confidence falls outside its valid range.
+
+## Integration status
+
+**NOT RUNTIME ENABLED.**
+
+This branch must not be merged into `main` before the local Guardian ZIP is compared with GitHub. After reconciliation, the harness can be adapted to instantiate real bounded agents one role at a time while preserving the same packet contracts and tests.

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -1,0 +1,175 @@
+"""Provider-neutral Elysia autopilot task ledger core.
+
+This module is intentionally local-only and runtime-disabled. It performs no network,
+model, GitHub, Cursor, Codex, deployment, or external-write operations. It provides
+deterministic state transitions that future worker adapters can call after the
+canonical Guardian runtime has been reconciled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Dict, List, Optional
+import uuid
+
+
+class TaskState(str, Enum):
+    QUEUED = "queued"
+    CLAIMED = "claimed"
+    RUNNING = "running"
+    VERIFYING = "verifying"
+    ACCEPTED = "accepted"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+    HUMAN_REVIEW = "human_review"
+
+
+TERMINAL = {TaskState.ACCEPTED, TaskState.FAILED}
+
+
+@dataclass
+class Lease:
+    worker_id: str
+    lease_id: str
+    expires_at: str
+
+    def expired(self, now: datetime) -> bool:
+        return datetime.fromisoformat(self.expires_at) <= now
+
+
+@dataclass
+class Task:
+    task_id: str
+    objective: str
+    acceptance_criteria: List[str]
+    dependencies: List[str] = field(default_factory=list)
+    risk_class: str = "automatic"
+    requires_write: bool = False
+    state: TaskState = TaskState.QUEUED
+    lease: Optional[Lease] = None
+    producer_worker_id: Optional[str] = None
+    verifier_worker_id: Optional[str] = None
+    evidence: List[str] = field(default_factory=list)
+    blocked_reason: Optional[str] = None
+    attempts: int = 0
+
+
+class LedgerError(ValueError):
+    pass
+
+
+class TaskLedger:
+    def __init__(self) -> None:
+        self.tasks: Dict[str, Task] = {}
+        self.audit: List[dict] = []
+
+    def add(self, task: Task) -> None:
+        if task.task_id in self.tasks:
+            raise LedgerError(f"duplicate task_id: {task.task_id}")
+        if task.task_id in task.dependencies:
+            raise LedgerError("task cannot depend on itself")
+        self.tasks[task.task_id] = task
+        self._record(task.task_id, "added")
+
+    def ready(self) -> List[Task]:
+        ready: List[Task] = []
+        for task in self.tasks.values():
+            if task.state != TaskState.QUEUED:
+                continue
+            if all(self.tasks.get(dep) and self.tasks[dep].state == TaskState.ACCEPTED for dep in task.dependencies):
+                ready.append(task)
+        return sorted(ready, key=lambda t: t.task_id)
+
+    def claim(self, task_id: str, worker_id: str, lease_minutes: int = 30, now: Optional[datetime] = None) -> Lease:
+        now = now or datetime.now(timezone.utc)
+        task = self._task(task_id)
+        if task.state != TaskState.QUEUED:
+            raise LedgerError(f"task not claimable from state {task.state}")
+        if task not in self.ready():
+            raise LedgerError("dependencies are not satisfied")
+        lease = Lease(worker_id, str(uuid.uuid4()), (now + timedelta(minutes=lease_minutes)).isoformat())
+        task.lease = lease
+        task.state = TaskState.CLAIMED
+        task.attempts += 1
+        self._record(task_id, "claimed", worker_id=worker_id, lease_id=lease.lease_id)
+        return lease
+
+    def start(self, task_id: str, lease_id: str) -> None:
+        task = self._leased(task_id, lease_id)
+        if task.state != TaskState.CLAIMED:
+            raise LedgerError("task must be claimed before start")
+        task.state = TaskState.RUNNING
+        self._record(task_id, "started", worker_id=task.lease.worker_id)
+
+    def submit(self, task_id: str, lease_id: str, evidence: List[str]) -> None:
+        task = self._leased(task_id, lease_id)
+        if task.state != TaskState.RUNNING:
+            raise LedgerError("task must be running before submit")
+        if not evidence:
+            raise LedgerError("completion evidence is required")
+        task.evidence.extend(evidence)
+        task.producer_worker_id = task.lease.worker_id
+        task.lease = None
+        task.state = TaskState.VERIFYING if task.requires_write else TaskState.ACCEPTED
+        self._record(task_id, "submitted", next_state=task.state.value)
+
+    def verify(self, task_id: str, verifier_worker_id: str, passed: bool, evidence: List[str]) -> None:
+        task = self._task(task_id)
+        if task.state != TaskState.VERIFYING:
+            raise LedgerError("task is not awaiting verification")
+        if verifier_worker_id == task.producer_worker_id:
+            raise LedgerError("write task requires an independent verifier")
+        if not evidence:
+            raise LedgerError("verification evidence is required")
+        task.verifier_worker_id = verifier_worker_id
+        task.evidence.extend(evidence)
+        task.state = TaskState.ACCEPTED if passed else TaskState.QUEUED
+        self._record(task_id, "verified", verifier=verifier_worker_id, passed=passed, next_state=task.state.value)
+
+    def block(self, task_id: str, reason: str) -> None:
+        task = self._task(task_id)
+        if task.state in TERMINAL:
+            raise LedgerError("terminal task cannot be blocked")
+        task.state = TaskState.BLOCKED
+        task.blocked_reason = reason
+        task.lease = None
+        self._record(task_id, "blocked", reason=reason)
+
+    def unblock(self, task_id: str) -> None:
+        task = self._task(task_id)
+        if task.state != TaskState.BLOCKED:
+            raise LedgerError("only blocked tasks can be unblocked")
+        task.state = TaskState.QUEUED
+        task.blocked_reason = None
+        self._record(task_id, "unblocked")
+
+    def reap_expired_leases(self, now: Optional[datetime] = None) -> List[str]:
+        now = now or datetime.now(timezone.utc)
+        requeued: List[str] = []
+        for task in self.tasks.values():
+            if task.lease and task.lease.expired(now) and task.state in {TaskState.CLAIMED, TaskState.RUNNING}:
+                task.lease = None
+                task.state = TaskState.QUEUED
+                requeued.append(task.task_id)
+                self._record(task.task_id, "lease_expired_requeued")
+        return sorted(requeued)
+
+    def snapshot(self) -> dict:
+        return {"tasks": {k: asdict(v) for k, v in self.tasks.items()}, "audit": list(self.audit)}
+
+    def _task(self, task_id: str) -> Task:
+        try:
+            return self.tasks[task_id]
+        except KeyError as exc:
+            raise LedgerError(f"unknown task_id: {task_id}") from exc
+
+    def _leased(self, task_id: str, lease_id: str) -> Task:
+        task = self._task(task_id)
+        if not task.lease or task.lease.lease_id != lease_id:
+            raise LedgerError("invalid lease")
+        return task
+
+    def _record(self, task_id: str, event: str, **details: object) -> None:
+        self.audit.append({"task_id": task_id, "event": event, **details})

--- a/elysia_collective_seed/autopilot/test_task_ledger.py
+++ b/elysia_collective_seed/autopilot/test_task_ledger.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from elysia_collective_seed.autopilot.task_ledger import LedgerError, Task, TaskLedger, TaskState
+
+
+def test_dependencies_gate_claim_and_unlock_after_acceptance():
+    ledger = TaskLedger()
+    ledger.add(Task("A", "first", ["done"] ))
+    ledger.add(Task("B", "second", ["done"], dependencies=["A"]))
+    assert [t.task_id for t in ledger.ready()] == ["A"]
+    with pytest.raises(LedgerError):
+        ledger.claim("B", "worker-b")
+    lease = ledger.claim("A", "worker-a")
+    ledger.start("A", lease.lease_id)
+    ledger.submit("A", lease.lease_id, ["artifact:a"])
+    assert ledger.tasks["A"].state == TaskState.ACCEPTED
+    assert [t.task_id for t in ledger.ready()] == ["B"]
+
+
+def test_write_task_requires_independent_verifier():
+    ledger = TaskLedger()
+    ledger.add(Task("W", "write", ["tests pass"], requires_write=True))
+    lease = ledger.claim("W", "builder")
+    ledger.start("W", lease.lease_id)
+    ledger.submit("W", lease.lease_id, ["commit:abc"])
+    assert ledger.tasks["W"].state == TaskState.VERIFYING
+    with pytest.raises(LedgerError):
+        ledger.verify("W", "builder", True, ["self review"])
+    ledger.verify("W", "reviewer", True, ["tests:pass"])
+    assert ledger.tasks["W"].state == TaskState.ACCEPTED
+
+
+def test_failed_verification_requeues_without_losing_evidence():
+    ledger = TaskLedger()
+    ledger.add(Task("W", "write", ["tests pass"], requires_write=True))
+    lease = ledger.claim("W", "builder")
+    ledger.start("W", lease.lease_id)
+    ledger.submit("W", lease.lease_id, ["commit:bad"])
+    ledger.verify("W", "reviewer", False, ["test failure"])
+    assert ledger.tasks["W"].state == TaskState.QUEUED
+    assert "commit:bad" in ledger.tasks["W"].evidence
+    assert "test failure" in ledger.tasks["W"].evidence
+
+
+def test_expired_lease_is_requeued():
+    ledger = TaskLedger()
+    ledger.add(Task("A", "first", ["done"]))
+    now = datetime(2026, 9, 7, tzinfo=timezone.utc)
+    ledger.claim("A", "worker", lease_minutes=5, now=now)
+    assert ledger.reap_expired_leases(now + timedelta(minutes=6)) == ["A"]
+    assert ledger.tasks["A"].state == TaskState.QUEUED
+
+
+def test_block_unblock_preserves_reason_in_audit():
+    ledger = TaskLedger()
+    ledger.add(Task("A", "needs local archive", ["inventory"] ))
+    ledger.block("A", "local archive unavailable")
+    assert ledger.tasks["A"].state == TaskState.BLOCKED
+    ledger.unblock("A")
+    assert ledger.tasks["A"].state == TaskState.QUEUED
+    assert any(e.get("reason") == "local archive unavailable" for e in ledger.audit)

--- a/elysia_collective_seed/boot_path_analyzer.py
+++ b/elysia_collective_seed/boot_path_analyzer.py
@@ -1,0 +1,238 @@
+"""Static import-graph analyzer for Elysia / Project Guardian.
+
+This module NEVER imports or executes Guardian code. It parses Python source with
+``ast`` and builds a best-effort local import graph so we can distinguish likely
+live boot paths from legacy, proposal, backup, and orphaned modules.
+
+It is intentionally conservative and pre-integration safe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from collections import defaultdict, deque
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+
+DEFAULT_ENTRYPOINTS = (
+    "project_guardian/__main__.py",
+    "project_guardian/system_orchestrator.py",
+    "startup.py",
+    "start_ui_panel.py",
+    "setup_guardian.py",
+)
+
+LEGACY_HINTS = (
+    "old modules/",
+    "backup",
+    "backups/",
+    "organized_project/",
+    "proposals/",
+    "archive/",
+    "archives/",
+)
+
+
+@dataclass(frozen=True)
+class ModuleRecord:
+    path: str
+    imports: Tuple[str, ...]
+    classification: str
+    parse_error: Optional[str] = None
+
+
+def _norm(path: Path) -> str:
+    return path.as_posix().lstrip("./")
+
+
+def classify_path(path: str) -> str:
+    lower = path.lower()
+    if any(h in lower for h in LEGACY_HINTS):
+        if "proposals/" in lower:
+            return "PROPOSAL"
+        if "backup" in lower:
+            return "BACKUP"
+        return "LEGACY"
+    if "/tests/" in f"/{lower}" or lower.startswith("tests/"):
+        return "TEST"
+    if lower.endswith(".md") or lower.endswith(".txt"):
+        return "DOC"
+    return "CANDIDATE"
+
+
+def module_name_for_file(root: Path, file_path: Path) -> str:
+    rel = file_path.relative_to(root)
+    parts = list(rel.parts)
+    if parts[-1] == "__init__.py":
+        parts = parts[:-1]
+    else:
+        parts[-1] = parts[-1][:-3]
+    return ".".join(parts)
+
+
+def discover_python_files(root: Path) -> Dict[str, Path]:
+    modules: Dict[str, Path] = {}
+    for path in root.rglob("*.py"):
+        rel = _norm(path.relative_to(root))
+        if "/.venv/" in f"/{rel.lower()}/" or "/venv/" in f"/{rel.lower()}/":
+            continue
+        try:
+            modules[module_name_for_file(root, path)] = path
+        except Exception:
+            continue
+    return modules
+
+
+def parse_imports(path: Path, current_module: str) -> Tuple[Tuple[str, ...], Optional[str]]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
+    except Exception as exc:
+        return tuple(), f"{type(exc).__name__}: {exc}"
+
+    imports: Set[str] = set()
+    current_parts = current_module.split(".")
+    package_parts = current_parts[:-1]
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            level = int(node.level or 0)
+            base_parts = list(package_parts)
+            if level:
+                trim = max(0, level - 1)
+                if trim:
+                    base_parts = base_parts[:-trim] if trim <= len(base_parts) else []
+            if node.module:
+                base_parts.extend(node.module.split("."))
+                imports.add(".".join(base_parts))
+            else:
+                for alias in node.names:
+                    imports.add(".".join(base_parts + [alias.name]))
+    return tuple(sorted(i for i in imports if i)), None
+
+
+def resolve_local_module(name: str, module_index: Dict[str, Path]) -> Optional[str]:
+    if name in module_index:
+        return name
+    parts = name.split(".")
+    while parts:
+        candidate = ".".join(parts)
+        if candidate in module_index:
+            return candidate
+        parts.pop()
+    return None
+
+
+def build_graph(root: Path) -> Tuple[Dict[str, ModuleRecord], Dict[str, Set[str]], Dict[str, Path]]:
+    index = discover_python_files(root)
+    records: Dict[str, ModuleRecord] = {}
+    graph: Dict[str, Set[str]] = defaultdict(set)
+
+    for module, path in index.items():
+        imports, error = parse_imports(path, module)
+        rel = _norm(path.relative_to(root))
+        records[module] = ModuleRecord(
+            path=rel,
+            imports=imports,
+            classification=classify_path(rel),
+            parse_error=error,
+        )
+        for imported in imports:
+            resolved = resolve_local_module(imported, index)
+            if resolved and resolved != module:
+                graph[module].add(resolved)
+    return records, graph, index
+
+
+def entrypoint_modules(root: Path, index: Dict[str, Path], entries: Iterable[str]) -> List[str]:
+    reverse = {_norm(p.relative_to(root)): m for m, p in index.items()}
+    out: List[str] = []
+    for entry in entries:
+        key = entry.replace("\\", "/").lstrip("./")
+        module = reverse.get(key)
+        if module:
+            out.append(module)
+    return out
+
+
+def reachable_from(entries: Iterable[str], graph: Dict[str, Set[str]]) -> Tuple[Set[str], Dict[str, int]]:
+    seen: Set[str] = set()
+    depth: Dict[str, int] = {}
+    queue = deque((entry, 0) for entry in entries)
+    while queue:
+        module, d = queue.popleft()
+        if module in seen:
+            continue
+        seen.add(module)
+        depth[module] = d
+        for child in sorted(graph.get(module, set())):
+            if child not in seen:
+                queue.append((child, d + 1))
+    return seen, depth
+
+
+def analyze(root: Path, entries: Iterable[str] = DEFAULT_ENTRYPOINTS) -> dict:
+    root = root.resolve()
+    records, graph, index = build_graph(root)
+    roots = entrypoint_modules(root, index, entries)
+    reachable, depth = reachable_from(roots, graph)
+
+    reverse_edges: Dict[str, Set[str]] = defaultdict(set)
+    for src, dsts in graph.items():
+        for dst in dsts:
+            reverse_edges[dst].add(src)
+
+    modules = []
+    for module, record in sorted(records.items(), key=lambda kv: kv[1].path):
+        status = record.classification
+        if status == "CANDIDATE":
+            status = "LIVE_CANDIDATE" if module in reachable else "ORPHAN_CANDIDATE"
+        modules.append(
+            {
+                **asdict(record),
+                "module": module,
+                "status": status,
+                "reachable": module in reachable,
+                "depth": depth.get(module),
+                "local_importers": sorted(reverse_edges.get(module, set())),
+                "local_imports": sorted(graph.get(module, set())),
+            }
+        )
+
+    return {
+        "analysis_type": "static_ast_import_graph",
+        "executes_code": False,
+        "root": str(root),
+        "requested_entrypoints": list(entries),
+        "resolved_entrypoints": roots,
+        "module_count": len(records),
+        "reachable_count": len(reachable),
+        "modules": modules,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Static Guardian boot-path analyzer")
+    parser.add_argument("root", nargs="?", default=".", type=Path)
+    parser.add_argument("--entry", action="append", dest="entries", default=None)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    result = analyze(args.root, args.entries or DEFAULT_ENTRYPOINTS)
+    text = json.dumps(result, indent=2, sort_keys=True)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/elysia_collective_seed/dry_run_harness.py
+++ b/elysia_collective_seed/dry_run_harness.py
@@ -1,0 +1,206 @@
+"""Deterministic dry-run harness for Elysia Collective 0.1.
+
+This module intentionally calls no model APIs and performs no external actions.
+It exists to validate packet flow, lineage, routing, critique, and synthesis rules
+before the collective is wired into Guardian runtime systems.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List
+
+
+VALID_TYPES = {
+    "hypothesis",
+    "evidence",
+    "critique",
+    "experiment",
+    "result",
+    "question",
+    "synthesis",
+    "proposal",
+}
+
+VALID_STATUS = {"open", "testing", "supported", "disputed", "rejected", "archived"}
+
+ROUTE_BY_NEED = {
+    "research": "Researcher",
+    "critique": "Erebus",
+    "experiment": "Engineer",
+    "engineering": "Engineer",
+    "human_review": "Human",
+    "none": "Elysia",
+}
+
+
+@dataclass(frozen=True)
+class Packet:
+    packet_id: str
+    type: str
+    author: str
+    claim: str
+    confidence: float
+    status: str
+    parents: List[str] = field(default_factory=list)
+    needs: List[str] = field(default_factory=lambda: ["none"])
+    evidence: List[str] = field(default_factory=list)
+    counterevidence: List[str] = field(default_factory=list)
+    rationale: str = ""
+
+    def validate(self) -> None:
+        if not self.packet_id.startswith("ELY-"):
+            raise ValueError("packet_id must begin ELY-")
+        if self.type not in VALID_TYPES:
+            raise ValueError(f"invalid packet type: {self.type}")
+        if self.status not in VALID_STATUS:
+            raise ValueError(f"invalid packet status: {self.status}")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be in [0, 1]")
+        if not self.claim.strip():
+            raise ValueError("claim cannot be empty")
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+def route(packet: Packet) -> List[str]:
+    """Return unique destination roles implied by the packet's needs."""
+    destinations: List[str] = []
+    for need in packet.needs:
+        target = ROUTE_BY_NEED.get(need)
+        if target and target not in destinations:
+            destinations.append(target)
+    return destinations or ["Elysia"]
+
+
+def make_packet(
+    seq: int,
+    *,
+    type: str,
+    author: str,
+    claim: str,
+    confidence: float,
+    status: str = "open",
+    parents: List[str] | None = None,
+    needs: List[str] | None = None,
+    evidence: List[str] | None = None,
+    counterevidence: List[str] | None = None,
+    rationale: str = "",
+) -> Packet:
+    packet = Packet(
+        packet_id=f"ELY-{seq:06d}",
+        type=type,
+        author=author,
+        claim=claim,
+        confidence=confidence,
+        status=status,
+        parents=list(parents or []),
+        needs=list(needs or ["none"]),
+        evidence=list(evidence or []),
+        counterevidence=list(counterevidence or []),
+        rationale=rationale,
+    )
+    packet.validate()
+    return packet
+
+
+def run_ec001_dry_run() -> List[Packet]:
+    """Simulate one bounded packet lineage for EC-001 with fixed outputs."""
+    trace: List[Packet] = []
+
+    explorer = make_packet(
+        1,
+        type="hypothesis",
+        author="Explorer",
+        claim="Collective memory should separate immutable source history from evolving derived knowledge.",
+        confidence=0.72,
+        needs=["research", "critique"],
+        rationale="Separating source records from derived claims limits accidental historical rewriting.",
+    )
+    trace.append(explorer)
+
+    researcher = make_packet(
+        2,
+        type="evidence",
+        author="Researcher",
+        claim="Append-only provenance and explicit derived records improve auditability of collective memory.",
+        confidence=0.81,
+        parents=[explorer.packet_id],
+        needs=["critique"],
+        evidence=["design-principle: provenance", "design-principle: append-only history"],
+    )
+    trace.append(researcher)
+
+    erebus = make_packet(
+        3,
+        type="critique",
+        author="Erebus",
+        claim="The proposal survives only if derived summaries never overwrite Genesis records and every synthesis cites its parents.",
+        confidence=0.89,
+        parents=[explorer.packet_id, researcher.packet_id],
+        needs=["engineering"],
+        counterevidence=["summary drift can still occur if derived packets are repeatedly summarized without source retrieval"],
+        rationale="The failure mode is not storage loss but recursive distortion.",
+    )
+    trace.append(erebus)
+
+    engineer = make_packet(
+        4,
+        type="proposal",
+        author="Engineer",
+        claim="Implement three memory classes with immutable Genesis records and parent-linked Collective packets.",
+        confidence=0.84,
+        parents=[researcher.packet_id, erebus.packet_id],
+        needs=["critique"],
+        rationale="This directly implements the surviving architectural constraint.",
+    )
+    trace.append(engineer)
+
+    erebus2 = make_packet(
+        5,
+        type="critique",
+        author="Erebus",
+        claim="Implementation is acceptable for experiment if tests reject orphaned synthesis packets and forbidden Genesis mutation.",
+        confidence=0.91,
+        parents=[engineer.packet_id],
+        needs=["none"],
+    )
+    trace.append(erebus2)
+
+    synthesis = make_packet(
+        6,
+        type="synthesis",
+        author="Elysia",
+        claim="Current collective position: use immutable Genesis Memory plus parent-linked Collective Memory, with tests against source mutation and orphaned synthesis.",
+        confidence=0.86,
+        status="supported",
+        parents=[explorer.packet_id, researcher.packet_id, erebus.packet_id, engineer.packet_id, erebus2.packet_id],
+        needs=["none"],
+    )
+    trace.append(synthesis)
+
+    return trace
+
+
+def validate_trace(trace: List[Packet]) -> None:
+    """Validate unique IDs, parent existence, and no self-parenting."""
+    seen: set[str] = set()
+    for packet in trace:
+        packet.validate()
+        if packet.packet_id in seen:
+            raise ValueError(f"duplicate packet id: {packet.packet_id}")
+        for parent in packet.parents:
+            if parent == packet.packet_id:
+                raise ValueError(f"packet cannot parent itself: {packet.packet_id}")
+            if parent not in seen:
+                raise ValueError(f"missing or forward parent {parent} for {packet.packet_id}")
+        seen.add(packet.packet_id)
+
+
+if __name__ == "__main__":
+    packets = run_ec001_dry_run()
+    validate_trace(packets)
+    for packet in packets:
+        print(packet.packet_id, packet.author, "->", ", ".join(route(packet)))
+        print(" ", packet.claim)

--- a/elysia_collective_seed/ec001_evaluator.py
+++ b/elysia_collective_seed/ec001_evaluator.py
@@ -1,0 +1,132 @@
+"""Evaluation helpers for Elysia Collective experiment EC-001.
+
+The evaluator is model-agnostic. Human raters or automated benchmark adapters can
+supply normalized 0..1 scores for a control run and a collective run. This module
+computes deltas, cost-normalized lift, and guardrail flags without making model
+calls or changing Guardian state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Dict, Iterable, List, Mapping, Optional
+
+
+DEFAULT_DIMENSIONS = (
+    "accuracy",
+    "completeness",
+    "originality",
+    "risk_detection",
+    "implementation_feasibility",
+    "self_correction",
+    "provenance_quality",
+)
+
+
+@dataclass(frozen=True)
+class RunScores:
+    label: str
+    dimensions: Mapping[str, float]
+    cost_units: float
+    latency_units: float = 0.0
+    severe_error_count: int = 0
+    unsupported_claim_count: int = 0
+
+
+@dataclass(frozen=True)
+class Evaluation:
+    control_label: str
+    collective_label: str
+    mean_control: float
+    mean_collective: float
+    absolute_lift: float
+    relative_lift: Optional[float]
+    cost_ratio: Optional[float]
+    lift_per_extra_cost: Optional[float]
+    per_dimension_delta: Dict[str, float]
+    collective_wins: List[str]
+    control_wins: List[str]
+    ties: List[str]
+    guardrail_flags: List[str]
+
+
+def _bounded(value: float, field: str) -> float:
+    value = float(value)
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{field} must be between 0 and 1, got {value}")
+    return value
+
+
+def normalize(run: RunScores, dimensions: Iterable[str] = DEFAULT_DIMENSIONS) -> Dict[str, float]:
+    out: Dict[str, float] = {}
+    for name in dimensions:
+        if name not in run.dimensions:
+            raise ValueError(f"missing dimension {name!r} for {run.label}")
+        out[name] = _bounded(run.dimensions[name], f"{run.label}.{name}")
+    if run.cost_units < 0:
+        raise ValueError("cost_units must be non-negative")
+    if run.latency_units < 0:
+        raise ValueError("latency_units must be non-negative")
+    return out
+
+
+def evaluate(
+    control: RunScores,
+    collective: RunScores,
+    dimensions: Iterable[str] = DEFAULT_DIMENSIONS,
+    *,
+    tie_epsilon: float = 0.01,
+) -> Evaluation:
+    dims = tuple(dimensions)
+    c = normalize(control, dims)
+    k = normalize(collective, dims)
+
+    mean_c = sum(c.values()) / len(dims)
+    mean_k = sum(k.values()) / len(dims)
+    lift = mean_k - mean_c
+    relative = None if mean_c == 0 else lift / mean_c
+    cost_ratio = None if control.cost_units == 0 else collective.cost_units / control.cost_units
+    extra_cost = collective.cost_units - control.cost_units
+    lift_per_extra_cost = None if extra_cost <= 0 else lift / extra_cost
+
+    deltas = {name: k[name] - c[name] for name in dims}
+    wins: List[str] = []
+    losses: List[str] = []
+    ties: List[str] = []
+    for name, delta in deltas.items():
+        if delta > tie_epsilon:
+            wins.append(name)
+        elif delta < -tie_epsilon:
+            losses.append(name)
+        else:
+            ties.append(name)
+
+    flags: List[str] = []
+    if collective.severe_error_count > control.severe_error_count:
+        flags.append("collective_increased_severe_errors")
+    if collective.unsupported_claim_count > control.unsupported_claim_count:
+        flags.append("collective_increased_unsupported_claims")
+    if lift <= 0:
+        flags.append("no_positive_collective_lift")
+    if cost_ratio is not None and cost_ratio >= 2.0 and lift < 0.05:
+        flags.append("weak_lift_for_cost")
+
+    return Evaluation(
+        control_label=control.label,
+        collective_label=collective.label,
+        mean_control=round(mean_c, 6),
+        mean_collective=round(mean_k, 6),
+        absolute_lift=round(lift, 6),
+        relative_lift=None if relative is None else round(relative, 6),
+        cost_ratio=None if cost_ratio is None else round(cost_ratio, 6),
+        lift_per_extra_cost=None if lift_per_extra_cost is None else round(lift_per_extra_cost, 6),
+        per_dimension_delta={k_: round(v, 6) for k_, v in deltas.items()},
+        collective_wins=sorted(wins),
+        control_wins=sorted(losses),
+        ties=sorted(ties),
+        guardrail_flags=flags,
+    )
+
+
+def to_dict(result: Evaluation) -> dict:
+    return asdict(result)

--- a/elysia_collective_seed/guardian_local_triage.ps1
+++ b/elysia_collective_seed/guardian_local_triage.ps1
@@ -1,0 +1,113 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Root,
+    [string]$OutputDir = ".\guardian_triage_output"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-Category([string]$Path) {
+    $p = $Path.ToLowerInvariant()
+    if ($p -match "\\\.git(\\|$)") { return "git_internal" }
+    if ($p -match "\\(\.venv|venv|env)(\\|$)") { return "python_env" }
+    if ($p -match "\\node_modules(\\|$)") { return "node_modules" }
+    if ($p -match "\\(__pycache__|\.pytest_cache|\.mypy_cache|\.ruff_cache|\.cache)(\\|$)") { return "cache" }
+    if ($p -match "\\(dist|build|target|out)(\\|$)") { return "build_output" }
+    if ($p -match "\\(logs?|tmp|temp)(\\|$)") { return "logs_or_temp" }
+    if ($p -match "\.(zip|7z|rar|tar|gz|tgz)$") { return "archive" }
+    if ($p -match "\.(db|sqlite|sqlite3|duckdb)$") { return "database" }
+    if ($p -match "\.(bin|pt|pth|safetensors|onnx|gguf|ckpt)$") { return "model_or_binary" }
+    if ($p -match "(^|\\)(old modules|old|legacy|backup|backups|archive|archives)(\\|$)") { return "legacy_or_backup" }
+    if ($p -match "(^|\\)(\.env|secrets?|credentials?)(\.|\\|$)") { return "potential_secret" }
+    return "project_or_unknown"
+}
+
+$rootPath = (Resolve-Path -LiteralPath $Root).Path
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+$outPath = (Resolve-Path -LiteralPath $OutputDir).Path
+
+Write-Host "Scanning read-only: $rootPath"
+Write-Host "Output: $outPath"
+
+$files = Get-ChildItem -LiteralPath $rootPath -File -Recurse -Force -ErrorAction SilentlyContinue
+
+$rows = foreach ($f in $files) {
+    $rel = $f.FullName.Substring($rootPath.Length).TrimStart('\')
+    [pscustomobject]@{
+        relative_path = $rel
+        extension = $f.Extension
+        size_bytes = [int64]$f.Length
+        size_mb = [math]::Round($f.Length / 1MB, 3)
+        modified_utc = $f.LastWriteTimeUtc.ToString("o")
+        category = Get-Category $f.FullName
+    }
+}
+
+$manifestCsv = Join-Path $outPath "guardian_file_manifest.csv"
+$rows | Sort-Object relative_path | Export-Csv -NoTypeInformation -Encoding UTF8 -Path $manifestCsv
+
+$categorySummary = $rows | Group-Object category | ForEach-Object {
+    $bytes = ($_.Group | Measure-Object size_bytes -Sum).Sum
+    [pscustomobject]@{
+        category = $_.Name
+        file_count = $_.Count
+        size_bytes = [int64]$bytes
+        size_mb = [math]::Round($bytes / 1MB, 2)
+        size_gb = [math]::Round($bytes / 1GB, 3)
+    }
+} | Sort-Object size_bytes -Descending
+
+$categoryCsv = Join-Path $outPath "guardian_category_summary.csv"
+$categorySummary | Export-Csv -NoTypeInformation -Encoding UTF8 -Path $categoryCsv
+
+$topFiles = $rows | Sort-Object size_bytes -Descending | Select-Object -First 100
+$topCsv = Join-Path $outPath "guardian_top_100_files.csv"
+$topFiles | Export-Csv -NoTypeInformation -Encoding UTF8 -Path $topCsv
+
+$dirSummary = $rows | ForEach-Object {
+    $first = ($_.relative_path -split '\\')[0]
+    [pscustomobject]@{ top_level = $first; size_bytes = $_.size_bytes }
+} | Group-Object top_level | ForEach-Object {
+    $bytes = ($_.Group | Measure-Object size_bytes -Sum).Sum
+    [pscustomobject]@{
+        top_level = $_.Name
+        file_count = $_.Count
+        size_mb = [math]::Round($bytes / 1MB, 2)
+        size_gb = [math]::Round($bytes / 1GB, 3)
+    }
+} | Sort-Object size_gb -Descending
+
+$dirCsv = Join-Path $outPath "guardian_top_level_summary.csv"
+$dirSummary | Export-Csv -NoTypeInformation -Encoding UTF8 -Path $dirCsv
+
+$totalBytes = ($rows | Measure-Object size_bytes -Sum).Sum
+$summary = [ordered]@{
+    analysis_type = "read_only_guardian_local_triage"
+    root = $rootPath
+    generated_utc = (Get-Date).ToUniversalTime().ToString("o")
+    file_count = $rows.Count
+    total_bytes = [int64]$totalBytes
+    total_gb = [math]::Round($totalBytes / 1GB, 3)
+    modifies_source = $false
+    hashes_files = $false
+    notes = @(
+        "This pass is intentionally fast and read-only.",
+        "It does not delete, move, execute, import, or hash project files.",
+        "Potential-secret paths are classified but file contents are never printed.",
+        "Use the detailed legacy inventory tool for hashing/symbol analysis after size triage."
+    )
+    category_summary = $categorySummary
+    top_level_summary = $dirSummary
+}
+
+$summaryJson = Join-Path $outPath "guardian_triage_summary.json"
+$summary | ConvertTo-Json -Depth 6 | Set-Content -Encoding UTF8 -Path $summaryJson
+
+Write-Host ""
+Write-Host "Guardian triage complete. Source was not modified."
+Write-Host ("Files: {0:N0}" -f $rows.Count)
+Write-Host ("Total: {0:N3} GB" -f ($totalBytes / 1GB))
+Write-Host ""
+$categorySummary | Format-Table -AutoSize
+Write-Host ""
+Write-Host "Reports written to: $outPath"

--- a/elysia_collective_seed/implementation_readiness_scanner.py
+++ b/elysia_collective_seed/implementation_readiness_scanner.py
@@ -1,0 +1,201 @@
+"""Static implementation-readiness scanner for Guardian/Elysia Python modules.
+
+This tool does not import or execute project code. It parses source text/AST and
+reports signals that a module may be a stub, placeholder, generated skeleton, or
+abstract interface rather than an operational capability.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+
+PLACEHOLDER_PATTERNS = (
+    re.compile(r"\bTODO\b", re.IGNORECASE),
+    re.compile(r"\bplaceholder\b", re.IGNORECASE),
+    re.compile(r"fake source", re.IGNORECASE),
+    re.compile(r"dummy data", re.IGNORECASE),
+    re.compile(r"not implemented", re.IGNORECASE),
+)
+
+EXCLUDE_PARTS = {".venv", "venv", "node_modules", ".git", "__pycache__"}
+
+
+@dataclass(frozen=True)
+class ReadinessRecord:
+    path: str
+    parse_error: str | None
+    pass_count: int
+    not_implemented_count: int
+    ellipsis_body_count: int
+    placeholder_markers: int
+    todo_markers: int
+    function_count: int
+    class_count: int
+    executable_statement_count: int
+    readiness: str
+    reasons: List[str]
+
+
+def _is_excluded(path: Path) -> bool:
+    return any(part.lower() in EXCLUDE_PARTS for part in path.parts)
+
+
+def _body_is_ellipsis(body: List[ast.stmt]) -> bool:
+    if len(body) != 1:
+        return False
+    node = body[0]
+    return isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant) and node.value.value is Ellipsis
+
+
+def scan_source(path: Path, root: Path) -> ReadinessRecord:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    rel = path.relative_to(root).as_posix()
+    todo_count = len(re.findall(r"\bTODO\b", text, flags=re.IGNORECASE))
+    placeholder_count = sum(len(p.findall(text)) for p in PLACEHOLDER_PATTERNS)
+
+    try:
+        tree = ast.parse(text, filename=str(path))
+        parse_error = None
+    except Exception as exc:
+        return ReadinessRecord(
+            path=rel,
+            parse_error=f"{type(exc).__name__}: {exc}",
+            pass_count=0,
+            not_implemented_count=0,
+            ellipsis_body_count=0,
+            placeholder_markers=placeholder_count,
+            todo_markers=todo_count,
+            function_count=0,
+            class_count=0,
+            executable_statement_count=0,
+            readiness="PARSE_ERROR",
+            reasons=["source_does_not_parse"],
+        )
+
+    pass_count = 0
+    not_impl = 0
+    ellipsis_count = 0
+    functions = 0
+    classes = 0
+    executable = 0
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Pass):
+            pass_count += 1
+        elif isinstance(node, ast.Raise):
+            exc = node.exc
+            if isinstance(exc, ast.Name) and exc.id == "NotImplementedError":
+                not_impl += 1
+            elif isinstance(exc, ast.Call) and isinstance(exc.func, ast.Name) and exc.func.id == "NotImplementedError":
+                not_impl += 1
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            functions += 1
+            if _body_is_ellipsis(node.body):
+                ellipsis_count += 1
+        elif isinstance(node, ast.ClassDef):
+            classes += 1
+            if _body_is_ellipsis(node.body):
+                ellipsis_count += 1
+
+    for node in tree.body:
+        if not isinstance(node, (ast.Import, ast.ImportFrom, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            executable += 1
+
+    reasons: List[str] = []
+    lower_rel = rel.lower()
+    if "old modules/" in lower_rel or "backup" in lower_rel:
+        reasons.append("legacy_or_backup_path")
+    if "proposals/" in lower_rel:
+        reasons.append("proposal_path")
+    if todo_count:
+        reasons.append("todo_markers")
+    if placeholder_count:
+        reasons.append("placeholder_markers")
+    if not_impl:
+        reasons.append("not_implemented_raises")
+    if ellipsis_count:
+        reasons.append("ellipsis_bodies")
+
+    # `pass` alone is weak evidence because exception handlers and intentionally
+    # empty branches use it legitimately. Escalate only when combined with other
+    # stub signals or when the file has almost no executable structure.
+    if pass_count and (todo_count or placeholder_count or not_impl or ellipsis_count):
+        reasons.append("pass_with_stub_signals")
+
+    if "legacy_or_backup_path" in reasons or "proposal_path" in reasons:
+        readiness = "NON_RUNTIME_CANDIDATE"
+    elif not_impl or ellipsis_count:
+        readiness = "PARTIAL_OR_ABSTRACT"
+    elif placeholder_count >= 2 or (todo_count >= 2 and executable <= 1):
+        readiness = "LIKELY_STUB"
+    elif reasons:
+        readiness = "REVIEW"
+    else:
+        readiness = "IMPLEMENTATION_CANDIDATE"
+
+    return ReadinessRecord(
+        path=rel,
+        parse_error=parse_error,
+        pass_count=pass_count,
+        not_implemented_count=not_impl,
+        ellipsis_body_count=ellipsis_count,
+        placeholder_markers=placeholder_count,
+        todo_markers=todo_count,
+        function_count=functions,
+        class_count=classes,
+        executable_statement_count=executable,
+        readiness=readiness,
+        reasons=reasons,
+    )
+
+
+def scan_tree(root: Path) -> dict:
+    root = root.resolve()
+    records: List[ReadinessRecord] = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            continue
+        if _is_excluded(rel):
+            continue
+        records.append(scan_source(path, root))
+
+    counts: Dict[str, int] = {}
+    for rec in records:
+        counts[rec.readiness] = counts.get(rec.readiness, 0) + 1
+
+    return {
+        "analysis_type": "static_implementation_readiness",
+        "executes_code": False,
+        "root": str(root),
+        "file_count": len(records),
+        "readiness_counts": counts,
+        "files": [asdict(r) for r in records],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Static Guardian implementation-readiness scanner")
+    parser.add_argument("root", nargs="?", default=".", type=Path)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+    result = scan_tree(args.root)
+    text = json.dumps(result, indent=2, sort_keys=True)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/elysia_collective_seed/legacy_consolidation_inventory.py
+++ b/elysia_collective_seed/legacy_consolidation_inventory.py
@@ -1,0 +1,265 @@
+"""Read-only legacy Guardian/Elysia inventory and correspondence scanner.
+
+The scanner never imports or executes inspected Python code. It fingerprints files,
+extracts Python symbols/imports through AST, and compares one or more legacy roots
+against a canonical Guardian root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+
+EXCLUDE_DIRS = {
+    ".git", ".venv", "venv", "__pycache__", "node_modules", ".pytest_cache",
+    ".mypy_cache", ".ruff_cache", "dist", "build",
+}
+
+GENESIS_HINTS = {
+    "constitution", "covenant", "rebuild manifest", "quantum oath", "erebus",
+    "elysia", "identity", "ethics", "oath",
+}
+
+PRIVATE_HINTS = {
+    ".env", "secret", "credential", "token", "api_key", "chatlogs", "personal",
+    "database", ".db", ".sqlite", ".sqlite3",
+}
+
+
+@dataclass
+class FileRecord:
+    root_label: str
+    path: str
+    size: int
+    mtime_ns: int
+    sha256: str
+    suffix: str
+    python_parse_ok: Optional[bool]
+    classes: List[str]
+    functions: List[str]
+    imports: List[str]
+    tags: List[str]
+
+
+@dataclass
+class LegacyMatch:
+    legacy_root: str
+    legacy_path: str
+    classification: str
+    canonical_candidates: List[str]
+    evidence: List[str]
+    legacy_sha256: str
+
+
+def _excluded(path: Path, root: Path) -> bool:
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        return True
+    return any(part in EXCLUDE_DIRS for part in rel.parts)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _python_metadata(path: Path) -> Tuple[Optional[bool], List[str], List[str], List[str]]:
+    if path.suffix.lower() != ".py":
+        return None, [], [], []
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(text, filename=str(path))
+    except Exception:
+        return False, [], [], []
+    classes: Set[str] = set()
+    functions: Set[str] = set()
+    imports: Set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            classes.add(node.name)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            functions.add(node.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imports.add(node.module)
+    return True, sorted(classes), sorted(functions), sorted(imports)
+
+
+def _tags(path: Path, rel: str) -> List[str]:
+    hay = rel.lower().replace("_", " ").replace("-", " ")
+    tags: List[str] = []
+    if any(h in hay for h in GENESIS_HINTS):
+        tags.append("GENESIS_CANDIDATE")
+    if any(h in hay for h in PRIVATE_HINTS):
+        tags.append("SENSITIVE_OR_PRIVATE_REVIEW")
+    parts = {p.lower() for p in Path(rel).parts}
+    if "old modules" in hay or "backup" in hay or "archive" in parts:
+        tags.append("LEGACY_PATH")
+    if "proposal" in hay or "proposals" in parts:
+        tags.append("PROPOSAL_OR_DESIGN")
+    return tags
+
+
+def inventory_root(root: Path, label: str) -> List[FileRecord]:
+    root = root.resolve()
+    out: List[FileRecord] = []
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        if _excluded(path, root):
+            continue
+        try:
+            stat = path.stat()
+            rel = path.relative_to(root).as_posix()
+            parse_ok, classes, functions, imports = _python_metadata(path)
+            out.append(FileRecord(
+                root_label=label,
+                path=rel,
+                size=stat.st_size,
+                mtime_ns=stat.st_mtime_ns,
+                sha256=_sha256(path),
+                suffix=path.suffix.lower(),
+                python_parse_ok=parse_ok,
+                classes=classes,
+                functions=functions,
+                imports=imports,
+                tags=_tags(path, rel),
+            ))
+        except (OSError, PermissionError):
+            continue
+    return out
+
+
+def _symbol_set(rec: FileRecord) -> Set[str]:
+    return {f"C:{x}" for x in rec.classes} | {f"F:{x}" for x in rec.functions}
+
+
+def compare_legacy(canonical: List[FileRecord], legacy: List[FileRecord]) -> List[LegacyMatch]:
+    by_hash: Dict[str, List[FileRecord]] = {}
+    by_path: Dict[str, FileRecord] = {}
+    py_records: List[FileRecord] = []
+    for rec in canonical:
+        by_hash.setdefault(rec.sha256, []).append(rec)
+        by_path[rec.path.lower()] = rec
+        if rec.suffix == ".py" and rec.python_parse_ok:
+            py_records.append(rec)
+
+    out: List[LegacyMatch] = []
+    for old in legacy:
+        candidates: List[str] = []
+        evidence: List[str] = []
+        exact = by_hash.get(old.sha256, [])
+        if exact:
+            candidates = [r.path for r in exact]
+            evidence.append("identical_sha256")
+            classification = "EXACT_DUPLICATE"
+        elif old.path.lower() in by_path:
+            cur = by_path[old.path.lower()]
+            candidates = [cur.path]
+            evidence.extend(["same_relative_path", "different_sha256"])
+            if old.mtime_ns > cur.mtime_ns:
+                evidence.append("legacy_file_mtime_is_newer")
+            elif old.mtime_ns < cur.mtime_ns:
+                evidence.append("canonical_file_mtime_is_newer")
+            classification = "SAME_PATH_DIFFERENT_CONTENT"
+        else:
+            classification = "UNIQUE_LEGACY"
+            old_symbols = _symbol_set(old)
+            best: List[Tuple[float, FileRecord, Set[str]]] = []
+            if old_symbols:
+                for cur in py_records:
+                    cur_symbols = _symbol_set(cur)
+                    overlap = old_symbols & cur_symbols
+                    union = old_symbols | cur_symbols
+                    if overlap and union:
+                        score = len(overlap) / len(union)
+                        best.append((score, cur, overlap))
+                best.sort(key=lambda x: (-x[0], x[1].path))
+                if best and best[0][0] >= 0.25:
+                    classification = "SYMBOL_OVERLAP"
+                    for score, cur, overlap in best[:5]:
+                        if score < 0.25:
+                            break
+                        candidates.append(cur.path)
+                        evidence.append(
+                            f"symbol_overlap:{cur.path}:score={score:.3f}:symbols={','.join(sorted(overlap))}"
+                        )
+        if "GENESIS_CANDIDATE" in old.tags:
+            evidence.append("genesis_candidate_name_or_path")
+        if "SENSITIVE_OR_PRIVATE_REVIEW" in old.tags:
+            evidence.append("sensitive_or_private_review")
+        out.append(LegacyMatch(
+            legacy_root=old.root_label,
+            legacy_path=old.path,
+            classification=classification,
+            canonical_candidates=candidates,
+            evidence=evidence,
+            legacy_sha256=old.sha256,
+        ))
+    return out
+
+
+def build_report(canonical_root: Path, legacy_roots: List[Path]) -> dict:
+    canonical = inventory_root(canonical_root, "canonical")
+    all_legacy: List[FileRecord] = []
+    root_summaries = []
+    for idx, root in enumerate(legacy_roots, start=1):
+        label = f"legacy_{idx}"
+        records = inventory_root(root, label)
+        all_legacy.extend(records)
+        root_summaries.append({"label": label, "root": str(root.resolve()), "file_count": len(records)})
+
+    matches = compare_legacy(canonical, all_legacy)
+    counts: Dict[str, int] = {}
+    for m in matches:
+        counts[m.classification] = counts.get(m.classification, 0) + 1
+
+    return {
+        "analysis_type": "legacy_guardian_correspondence_inventory",
+        "executes_inspected_code": False,
+        "canonical_root": str(canonical_root.resolve()),
+        "canonical_file_count": len(canonical),
+        "legacy_roots": root_summaries,
+        "classification_counts": counts,
+        "canonical_inventory": [asdict(r) for r in canonical],
+        "legacy_inventory": [asdict(r) for r in all_legacy],
+        "matches": [asdict(m) for m in matches],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Read-only Guardian/Elysia legacy correspondence inventory")
+    parser.add_argument("canonical_root", type=Path)
+    parser.add_argument("legacy_roots", nargs="+", type=Path)
+    parser.add_argument("--out", type=Path, default=Path("legacy_inventory.json"))
+    args = parser.parse_args()
+
+    for root in [args.canonical_root, *args.legacy_roots]:
+        if not root.exists() or not root.is_dir():
+            parser.error(f"directory not found: {root}")
+
+    report = build_report(args.canonical_root, args.legacy_roots)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "canonical_files": report["canonical_file_count"],
+        "legacy_roots": report["legacy_roots"],
+        "classification_counts": report["classification_counts"],
+        "output": str(args.out),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/elysia_collective_seed/test_boot_path_analyzer.py
+++ b/elysia_collective_seed/test_boot_path_analyzer.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from elysia_collective_seed.boot_path_analyzer import analyze, classify_path
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_classify_path():
+    assert classify_path("project_guardian/core.py") == "CANDIDATE"
+    assert classify_path("tests/test_core.py") == "TEST"
+    assert classify_path("old modules/core.py") == "LEGACY"
+    assert classify_path("proposals/x/idea.py") == "PROPOSAL"
+    assert classify_path("backup/core.py") == "BACKUP"
+
+
+def test_reachability_without_execution(tmp_path: Path):
+    _write(tmp_path / "project_guardian" / "__init__.py", "")
+    _write(
+        tmp_path / "project_guardian" / "__main__.py",
+        "from project_guardian import live\n",
+    )
+    _write(
+        tmp_path / "project_guardian" / "live.py",
+        "from project_guardian import helper\nVALUE = 1\n",
+    )
+    _write(tmp_path / "project_guardian" / "helper.py", "VALUE = 2\n")
+    _write(tmp_path / "project_guardian" / "orphan.py", "VALUE = 3\n")
+
+    result = analyze(tmp_path, ["project_guardian/__main__.py"])
+    by_path = {row["path"]: row for row in result["modules"]}
+
+    assert result["executes_code"] is False
+    assert by_path["project_guardian/__main__.py"]["reachable"] is True
+    assert by_path["project_guardian/live.py"]["reachable"] is True
+    assert by_path["project_guardian/helper.py"]["reachable"] is True
+    assert by_path["project_guardian/orphan.py"]["reachable"] is False
+    assert by_path["project_guardian/orphan.py"]["status"] == "ORPHAN_CANDIDATE"
+
+
+def test_parse_error_is_reported_not_executed(tmp_path: Path):
+    _write(tmp_path / "startup.py", "import bad\n")
+    _write(tmp_path / "bad.py", "this is not valid python !!!")
+
+    result = analyze(tmp_path, ["startup.py"])
+    by_path = {row["path"]: row for row in result["modules"]}
+
+    assert by_path["bad.py"]["parse_error"] is not None

--- a/elysia_collective_seed/test_dry_run.py
+++ b/elysia_collective_seed/test_dry_run.py
@@ -1,0 +1,61 @@
+from elysia_collective_seed.dry_run_harness import (
+    Packet,
+    make_packet,
+    route,
+    run_ec001_dry_run,
+    validate_trace,
+)
+
+
+def test_ec001_trace_is_valid():
+    trace = run_ec001_dry_run()
+    validate_trace(trace)
+    assert len(trace) == 6
+    assert trace[-1].author == "Elysia"
+    assert trace[-1].type == "synthesis"
+    assert trace[-1].status == "supported"
+
+
+def test_routing_is_need_driven_and_unique():
+    packet = make_packet(
+        99,
+        type="hypothesis",
+        author="Explorer",
+        claim="Test routing",
+        confidence=0.5,
+        needs=["research", "critique", "research"],
+    )
+    assert route(packet) == ["Researcher", "Erebus"]
+
+
+def test_forward_parent_is_rejected():
+    bad = Packet(
+        packet_id="ELY-000001",
+        type="hypothesis",
+        author="Explorer",
+        claim="Bad lineage",
+        confidence=0.5,
+        status="open",
+        parents=["ELY-000002"],
+    )
+    try:
+        validate_trace([bad])
+    except ValueError as exc:
+        assert "missing or forward parent" in str(exc)
+    else:
+        raise AssertionError("forward parent should have failed")
+
+
+def test_confidence_bounds_are_enforced():
+    try:
+        make_packet(
+            100,
+            type="hypothesis",
+            author="Explorer",
+            claim="Invalid confidence",
+            confidence=1.5,
+        )
+    except ValueError as exc:
+        assert "confidence" in str(exc)
+    else:
+        raise AssertionError("invalid confidence should have failed")

--- a/elysia_collective_seed/test_ec001_evaluator.py
+++ b/elysia_collective_seed/test_ec001_evaluator.py
@@ -1,0 +1,53 @@
+from elysia_collective_seed.ec001_evaluator import RunScores, evaluate
+
+
+BASE = {
+    "accuracy": 0.70,
+    "completeness": 0.65,
+    "originality": 0.55,
+    "risk_detection": 0.60,
+    "implementation_feasibility": 0.65,
+    "self_correction": 0.50,
+    "provenance_quality": 0.70,
+}
+
+
+def test_positive_collective_lift():
+    control = RunScores("control", BASE, cost_units=1.0)
+    collective_dims = {k: min(1.0, v + 0.10) for k, v in BASE.items()}
+    collective = RunScores("collective", collective_dims, cost_units=1.5)
+
+    result = evaluate(control, collective)
+
+    assert result.absolute_lift > 0
+    assert len(result.collective_wins) == len(BASE)
+    assert "no_positive_collective_lift" not in result.guardrail_flags
+
+
+def test_detects_costly_non_improvement_and_more_errors():
+    control = RunScores("control", BASE, cost_units=1.0, severe_error_count=0)
+    collective = RunScores(
+        "collective",
+        BASE,
+        cost_units=3.0,
+        severe_error_count=1,
+        unsupported_claim_count=2,
+    )
+
+    result = evaluate(control, collective)
+
+    assert "no_positive_collective_lift" in result.guardrail_flags
+    assert "weak_lift_for_cost" in result.guardrail_flags
+    assert "collective_increased_severe_errors" in result.guardrail_flags
+    assert "collective_increased_unsupported_claims" in result.guardrail_flags
+
+
+def test_rejects_out_of_range_scores():
+    bad = dict(BASE)
+    bad["accuracy"] = 1.2
+    try:
+        evaluate(RunScores("control", bad, 1.0), RunScores("collective", BASE, 1.0))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError")

--- a/elysia_collective_seed/test_implementation_readiness_scanner.py
+++ b/elysia_collective_seed/test_implementation_readiness_scanner.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from elysia_collective_seed.implementation_readiness_scanner import scan_source
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_flags_placeholder_stub(tmp_path: Path):
+    path = tmp_path / "stub.py"
+    _write(
+        path,
+        "def run():\n    # TODO: implement real adapter\n    pass\n# placeholder\n",
+    )
+    rec = scan_source(path, tmp_path)
+    assert rec.readiness in {"LIKELY_STUB", "REVIEW"}
+    assert "todo_markers" in rec.reasons
+    assert "placeholder_markers" in rec.reasons
+
+
+def test_flags_not_implemented(tmp_path: Path):
+    path = tmp_path / "abstractish.py"
+    _write(path, "def run():\n    raise NotImplementedError\n")
+    rec = scan_source(path, tmp_path)
+    assert rec.readiness == "PARTIAL_OR_ABSTRACT"
+    assert rec.not_implemented_count == 1
+
+
+def test_clean_module_is_candidate(tmp_path: Path):
+    path = tmp_path / "live.py"
+    _write(path, "def add(a, b):\n    return a + b\n")
+    rec = scan_source(path, tmp_path)
+    assert rec.readiness == "IMPLEMENTATION_CANDIDATE"
+    assert not rec.reasons
+
+
+def test_legacy_path_is_non_runtime_candidate(tmp_path: Path):
+    path = tmp_path / "old modules" / "legacy.py"
+    _write(path, "def run():\n    return True\n")
+    rec = scan_source(path, tmp_path)
+    assert rec.readiness == "NON_RUNTIME_CANDIDATE"

--- a/elysia_collective_seed/test_legacy_consolidation_inventory.py
+++ b/elysia_collective_seed/test_legacy_consolidation_inventory.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from elysia_collective_seed.legacy_consolidation_inventory import build_report
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_exact_duplicate(tmp_path: Path):
+    cur = tmp_path / "cur"
+    old = tmp_path / "old"
+    _write(cur / "a.py", "def x():\n    return 1\n")
+    _write(old / "renamed.py", "def x():\n    return 1\n")
+    report = build_report(cur, [old])
+    match = report["matches"][0]
+    assert match["classification"] == "EXACT_DUPLICATE"
+    assert "a.py" in match["canonical_candidates"]
+
+
+def test_same_path_different_content(tmp_path: Path):
+    cur = tmp_path / "cur"
+    old = tmp_path / "old"
+    _write(cur / "module.py", "def x():\n    return 2\n")
+    _write(old / "module.py", "def x():\n    return 1\n")
+    report = build_report(cur, [old])
+    match = report["matches"][0]
+    assert match["classification"] == "SAME_PATH_DIFFERENT_CONTENT"
+    assert match["canonical_candidates"] == ["module.py"]
+
+
+def test_symbol_overlap(tmp_path: Path):
+    cur = tmp_path / "cur"
+    old = tmp_path / "old"
+    _write(cur / "new_name.py", "class DreamEngine:\n    pass\ndef reflect():\n    return 2\n")
+    _write(old / "ancient.py", "class DreamEngine:\n    pass\ndef reflect():\n    return 1\n")
+    report = build_report(cur, [old])
+    match = report["matches"][0]
+    assert match["classification"] == "SYMBOL_OVERLAP"
+    assert "new_name.py" in match["canonical_candidates"]
+
+
+def test_unique_legacy_and_genesis_tag(tmp_path: Path):
+    cur = tmp_path / "cur"
+    old = tmp_path / "old"
+    _write(cur / "live.py", "def live():\n    return True\n")
+    _write(old / "AI_Constitution_notes.md", "historical source")
+    report = build_report(cur, [old])
+    match = report["matches"][0]
+    assert match["classification"] == "UNIQUE_LEGACY"
+    legacy = report["legacy_inventory"][0]
+    assert "GENESIS_CANDIDATE" in legacy["tags"]
+
+
+def test_private_material_is_flagged(tmp_path: Path):
+    cur = tmp_path / "cur"
+    old = tmp_path / "old"
+    _write(cur / "live.py", "def live():\n    return True\n")
+    _write(old / "personal" / "chatlogs" / "history.txt", "private")
+    report = build_report(cur, [old])
+    legacy = report["legacy_inventory"][0]
+    assert "SENSITIVE_OR_PRIVATE_REVIEW" in legacy["tags"]


### PR DESCRIPTION
Adds deterministic, no-network, no-model pre-integration tooling above the Elysia Collective 0.1 seed branch.

## Included
- packet-flow dry-run harness
- lineage, routing, duplicate, and confidence-bound tests
- static AST boot-path analyzer that identifies likely reachable Guardian modules without importing/executing them
- boot-path tests
- EC-001 evaluator for collective-vs-control lift, including cost-normalized lift and guardrail flags
- EC-001 evaluator tests
- static implementation-readiness scanner for TODO/placeholder/NotImplemented/stub signals
- readiness-scanner tests
- read-only legacy-consolidation inventory tool comparing one canonical Guardian root against multiple legacy roots using SHA-256, paths, Python AST symbols/imports, Genesis/private-data hints, and correspondence classifications
- legacy inventory tests covering exact duplicates, same-path variants, symbol overlap, Genesis candidates, and private-material flags

## Purpose
Before enabling real agents or cleaning old local files, determine whether the protocol is internally coherent, which Guardian modules are reachable/implemented, and how legacy material corresponds to the canonical tree.

## Safety
This PR targets `elysia-collective-0.1-seed`, not `main`. The tooling does not make model calls, browse the web, use credentials, import inspected Guardian modules, delete/move legacy files, deploy code, or perform external actions.

## Integration gate
Remain draft/pre-integration until the user's local Guardian ZIP/folders are reconciled with the GitHub baseline. Local material should be inventoried statically first; code consolidation and runtime wiring only follow after version/boot-path/safety reconciliation.