### PR TITLE
AUTOPILOT-004 dispatcher foundation [DRAFT]

### DIFF
--- a/.github/workflows/elysia-autopilot-ci.yml
+++ b/.github/workflows/elysia-autopilot-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'elysia-collective-*'
+      - 'autopilot-*'
   pull_request:
     branches:
       - main
@@ -48,9 +49,7 @@ jobs:
           print('All JSON artifacts parsed successfully.')
 
       - name: Run Elysia Collective seed tests
-        run: |
-          python -m pytest -q \
-            elysia_collective_seed/test_*.py
+        run: python -m pytest -q elysia_collective_seed
 
       - name: Enforce no runtime-enable flag in seed prompt pack
         shell: python

--- a/elysia_collective_seed/autopilot/completion_validator.py
+++ b/elysia_collective_seed/autopilot/completion_validator.py
@@ -1,0 +1,112 @@
+"""Provider-neutral completion packet validation for AUTOPILOT-004.
+
+This module is deliberately runtime-disabled and side-effect free. It validates the
+minimum semantic contract required before a worker completion may be considered for
+ledger state transition. It does not invoke providers, write GitHub state, execute
+Guardian runtime code, merge, or deploy.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+OUTCOMES = {"completed", "partial", "blocked", "failed", "rejected"}
+NEXT_ACTIONS = {"verify", "continue", "retry", "spawn_followup", "human_review", "archive", "none"}
+CHECK_RESULTS = {"pass", "fail", "skip", "not_run"}
+
+
+@dataclass(frozen=True)
+class CompletionValidation:
+    valid: bool
+    task_id: str | None
+    outcome: str | None
+    reasons: tuple[str, ...]
+
+
+def _nonempty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def validate_completion(
+    packet: Mapping,
+    *,
+    expected_task_id: str | None = None,
+    required_checks: Sequence[str] = (),
+) -> CompletionValidation:
+    """Validate a completion packet without mutating persistent state.
+
+    JSON Schema remains the structural source of truth. This function adds the
+    semantic checks needed by the orchestrator before accepting a completion:
+    task identity, meaningful worker attribution, known outcomes/actions, unique
+    check names, required-check presence, and no failed required checks.
+    """
+    reasons: list[str] = []
+    task_id = packet.get("task_id")
+    outcome = packet.get("outcome")
+
+    if not _nonempty_string(task_id):
+        reasons.append("invalid_task_id")
+        task_id_s = None
+    else:
+        task_id_s = str(task_id)
+        if expected_task_id is not None and task_id_s != expected_task_id:
+            reasons.append("task_id_mismatch")
+
+    if outcome not in OUTCOMES:
+        reasons.append("invalid_outcome")
+        outcome_s = None
+    else:
+        outcome_s = str(outcome)
+
+    if not _nonempty_string(packet.get("summary")):
+        reasons.append("missing_summary")
+
+    worker = packet.get("worker")
+    if not isinstance(worker, Mapping):
+        reasons.append("invalid_worker")
+    else:
+        if not _nonempty_string(worker.get("provider")):
+            reasons.append("missing_worker_provider")
+        if not _nonempty_string(worker.get("role")):
+            reasons.append("missing_worker_role")
+
+    recommendation = packet.get("next_recommendation")
+    if not isinstance(recommendation, Mapping) or recommendation.get("action") not in NEXT_ACTIONS:
+        reasons.append("invalid_next_recommendation")
+
+    checks = packet.get("checks")
+    seen: dict[str, str] = {}
+    if not isinstance(checks, list):
+        reasons.append("invalid_checks")
+    else:
+        for check in checks:
+            if not isinstance(check, Mapping) or not _nonempty_string(check.get("name")):
+                reasons.append("invalid_check")
+                continue
+            name = str(check["name"])
+            result = check.get("result")
+            if result not in CHECK_RESULTS:
+                reasons.append(f"invalid_check_result:{name}")
+                continue
+            if name in seen:
+                reasons.append(f"duplicate_check:{name}")
+            seen[name] = str(result)
+
+    for name in required_checks:
+        result = seen.get(name)
+        if result is None:
+            reasons.append(f"missing_required_check:{name}")
+        elif result != "pass":
+            reasons.append(f"required_check_not_passed:{name}:{result}")
+
+    # A worker may report completed only when its own declared checks contain no
+    # explicit failures. Independent verification remains a separate later gate.
+    if outcome_s == "completed" and any(result == "fail" for result in seen.values()):
+        reasons.append("completed_with_failed_check")
+
+    return CompletionValidation(
+        valid=not reasons,
+        task_id=task_id_s,
+        outcome=outcome_s,
+        reasons=tuple(reasons),
+    )

--- a/elysia_collective_seed/autopilot/dispatcher.py
+++ b/elysia_collective_seed/autopilot/dispatcher.py
@@ -1,0 +1,112 @@
+"""Provider-neutral deterministic dispatcher foundation.
+
+Runtime-disabled: this module selects/validates work but does not invoke external
+providers, execute project code, merge branches, or perform deployments.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+AUTO_RISKS = {"read_only", "sandbox_write", "repo_write"}
+PROTECTED_RISKS = {"external_write", "deployment", "sensitive_data", "privileged"}
+TERMINAL = {"completed", "rejected", "archived"}
+
+
+@dataclass(frozen=True)
+class Worker:
+    worker_id: str
+    provider: str
+    capabilities: frozenset[str]
+    risk_classes: frozenset[str]
+    available: bool = True
+    quality: float = 0.5
+    cost: float = 0.5
+
+
+@dataclass(frozen=True)
+class DispatchDecision:
+    task_id: str
+    state: str
+    worker_id: str | None
+    reasons: tuple[str, ...]
+
+
+def _deps_satisfied(task: Mapping, states: Mapping[str, str]) -> bool:
+    return all(states.get(dep) == "completed" for dep in task.get("dependencies", []))
+
+
+def _required_capabilities(task: Mapping) -> set[str]:
+    caps = set(task.get("required_capabilities", []))
+    task_class = task.get("task_class")
+    if task_class:
+        caps.add(str(task_class))
+    return caps
+
+
+def eligible_workers(task: Mapping, workers: Iterable[Worker]) -> list[Worker]:
+    required = _required_capabilities(task)
+    risk = task["risk_class"]
+    allowed = set(task.get("allowed_workers", []))
+    result = []
+    for worker in workers:
+        if not worker.available or risk not in worker.risk_classes:
+            continue
+        if allowed and worker.worker_id not in allowed:
+            continue
+        if not required.issubset(worker.capabilities):
+            continue
+        result.append(worker)
+    return result
+
+
+def _score(worker: Worker, preferred: str | None) -> tuple[float, str]:
+    # Deterministic: quality dominates, then lower cost; preferred worker gets a
+    # small bounded bonus. worker_id is a stable final tie-breaker.
+    score = worker.quality - (0.25 * worker.cost)
+    if preferred and worker.worker_id == preferred:
+        score += 0.10
+    return score, worker.worker_id
+
+
+def dispatch(task: Mapping, states: Mapping[str, str], workers: Sequence[Worker]) -> DispatchDecision:
+    task_id = task["task_id"]
+    status = task.get("status", "queued")
+    risk = task["risk_class"]
+
+    if status in TERMINAL:
+        return DispatchDecision(task_id, "not_dispatchable", None, ("terminal_task",))
+    if task.get("human_approval_required", False) or risk in PROTECTED_RISKS:
+        return DispatchDecision(task_id, "human_gate", None, ("authority_gate",))
+    if risk not in AUTO_RISKS:
+        return DispatchDecision(task_id, "blocked", None, ("unknown_risk_class",))
+    if not _deps_satisfied(task, states):
+        return DispatchDecision(task_id, "blocked", None, ("dependencies_incomplete",))
+    if int(task.get("attempt", 0)) >= int(task.get("max_attempts", 3)):
+        return DispatchDecision(task_id, "blocked", None, ("attempt_limit_reached",))
+
+    eligible = eligible_workers(task, workers)
+    if not eligible:
+        return DispatchDecision(task_id, "blocked", None, ("no_eligible_worker",))
+    preferred = task.get("preferred_worker")
+    chosen = max(eligible, key=lambda w: _score(w, preferred))
+    return DispatchDecision(task_id, "dispatch", chosen.worker_id, ("eligible",))
+
+
+def validate_followup(parent: Mapping, proposal: Mapping, open_tasks: Sequence[Mapping]) -> tuple[bool, tuple[str, ...]]:
+    """Bound autonomous follow-up generation without granting new authority."""
+    reasons: list[str] = []
+    if proposal.get("risk_class") not in AUTO_RISKS:
+        reasons.append("authority_expansion")
+    if proposal.get("human_approval_required", False):
+        reasons.append("human_gate")
+    if not proposal.get("acceptance_criteria"):
+        reasons.append("missing_acceptance_criteria")
+    parent_sources = set(parent.get("source_refs", []))
+    proposed_sources = set(proposal.get("source_refs", []))
+    if not proposed_sources.issubset(parent_sources):
+        reasons.append("source_scope_expansion")
+    normalized = proposal.get("title", "").strip().casefold()
+    if normalized and any(t.get("title", "").strip().casefold() == normalized for t in open_tasks):
+        reasons.append("duplicate_open_task")
+    return not reasons, tuple(reasons)

--- a/elysia_collective_seed/autopilot/dryrun_orchestrator.py
+++ b/elysia_collective_seed/autopilot/dryrun_orchestrator.py
@@ -2,14 +2,15 @@
 
 This module is deliberately provider-free and runtime-disabled. It does not invoke
 models, subprocesses, Guardian runtime code, network services, GitHub writes,
-merges, or deployments. It only makes a deterministic dispatch decision and, when
-eligible, atomically acquires a local SQLite lease for the selected worker.
+merges, or deployments. It only makes deterministic dispatch/completion decisions
+and persists bounded local SQLite state transitions.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Mapping, Sequence
 
+from .completion_validator import CompletionValidation, validate_completion
 from .dispatcher import DispatchDecision, Worker, dispatch
 from .task_ledger import ClaimResult, TaskLedger
 
@@ -21,6 +22,16 @@ class DryRunResult:
     worker_id: str | None
     dispatch: DispatchDecision
     claim: ClaimResult | None
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CompletionResult:
+    task_id: str
+    state: str
+    worker_id: str
+    validation: CompletionValidation
+    applied: bool
     reasons: tuple[str, ...]
 
 
@@ -71,4 +82,82 @@ def dispatch_and_claim(
         dispatch=decision,
         claim=claim,
         reasons=(claim.reason,),
+    )
+
+
+def validate_and_apply_completion(
+    ledger: TaskLedger,
+    packet: Mapping,
+    *,
+    worker_id: str,
+    required_checks: Sequence[str] = (),
+) -> CompletionResult:
+    """Validate a worker completion and apply only a bounded ledger transition.
+
+    A worker's `completed` report does not make a task completed. It moves the
+    task to `verifying`, preserving the independent-verifier gate. Partial/failed
+    work returns to `queued`; blocked work becomes `blocked`; rejected work becomes
+    terminal `rejected`. The ledger lease owner must match `worker_id`, so a stale
+    or unrelated completion cannot mutate another worker's task.
+    """
+    task_id = str(packet.get("task_id", ""))
+    validation = validate_completion(
+        packet,
+        expected_task_id=task_id or None,
+        required_checks=required_checks,
+    )
+    if not validation.valid or validation.task_id is None or validation.outcome is None:
+        return CompletionResult(
+            task_id=task_id,
+            state="validation_rejected",
+            worker_id=worker_id,
+            validation=validation,
+            applied=False,
+            reasons=validation.reasons,
+        )
+
+    persisted = ledger.get(validation.task_id)
+    if persisted is None:
+        return CompletionResult(
+            task_id=validation.task_id,
+            state="completion_rejected",
+            worker_id=worker_id,
+            validation=validation,
+            applied=False,
+            reasons=("task_not_found",),
+        )
+    if persisted.get("claimed_by") != worker_id:
+        return CompletionResult(
+            task_id=validation.task_id,
+            state="completion_rejected",
+            worker_id=worker_id,
+            validation=validation,
+            applied=False,
+            reasons=("lease_owner_mismatch",),
+        )
+
+    next_state = {
+        "completed": "verifying",
+        "partial": "queued",
+        "blocked": "blocked",
+        "failed": "queued",
+        "rejected": "rejected",
+    }[validation.outcome]
+    applied = ledger.release(validation.task_id, worker_id, next_status=next_state)
+    if not applied:
+        return CompletionResult(
+            task_id=validation.task_id,
+            state="completion_rejected",
+            worker_id=worker_id,
+            validation=validation,
+            applied=False,
+            reasons=("lease_release_failed",),
+        )
+    return CompletionResult(
+        task_id=validation.task_id,
+        state=next_state,
+        worker_id=worker_id,
+        validation=validation,
+        applied=True,
+        reasons=("completion_applied",),
     )

--- a/elysia_collective_seed/autopilot/dryrun_orchestrator.py
+++ b/elysia_collective_seed/autopilot/dryrun_orchestrator.py
@@ -1,0 +1,74 @@
+"""Dry-run orchestration bridge between dispatcher and persistent task ledger.
+
+This module is deliberately provider-free and runtime-disabled. It does not invoke
+models, subprocesses, Guardian runtime code, network services, GitHub writes,
+merges, or deployments. It only makes a deterministic dispatch decision and, when
+eligible, atomically acquires a local SQLite lease for the selected worker.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from .dispatcher import DispatchDecision, Worker, dispatch
+from .task_ledger import ClaimResult, TaskLedger
+
+
+@dataclass(frozen=True)
+class DryRunResult:
+    task_id: str
+    state: str
+    worker_id: str | None
+    dispatch: DispatchDecision
+    claim: ClaimResult | None
+    reasons: tuple[str, ...]
+
+
+def dispatch_and_claim(
+    ledger: TaskLedger,
+    task: Mapping,
+    states: Mapping[str, str],
+    workers: Sequence[Worker],
+    lease_seconds: int = 900,
+) -> DryRunResult:
+    """Persist a task, dispatch it, and atomically claim it for the chosen worker.
+
+    The ledger's persisted status is authoritative when the task already exists,
+    preventing stale caller payloads from reopening terminal or actively leased
+    work. No provider is invoked after a successful claim.
+    """
+    ledger.put_task(task)
+    persisted = ledger.get(str(task["task_id"]))
+    if persisted is None:
+        raise RuntimeError("task disappeared after ledger upsert")
+
+    decision = dispatch(persisted, states, workers)
+    if decision.state != "dispatch" or decision.worker_id is None:
+        return DryRunResult(
+            task_id=decision.task_id,
+            state=decision.state,
+            worker_id=None,
+            dispatch=decision,
+            claim=None,
+            reasons=decision.reasons,
+        )
+
+    claim = ledger.claim(decision.task_id, decision.worker_id, lease_seconds=lease_seconds)
+    if not claim.claimed:
+        return DryRunResult(
+            task_id=decision.task_id,
+            state="claim_blocked",
+            worker_id=decision.worker_id,
+            dispatch=decision,
+            claim=claim,
+            reasons=(claim.reason,),
+        )
+
+    return DryRunResult(
+        task_id=decision.task_id,
+        state="claimed",
+        worker_id=decision.worker_id,
+        dispatch=decision,
+        claim=claim,
+        reasons=(claim.reason,),
+    )

--- a/elysia_collective_seed/autopilot/handoffs/2026-09-07-ci-import-repair.md
+++ b/elysia_collective_seed/autopilot/handoffs/2026-09-07-ci-import-repair.md
@@ -1,0 +1,22 @@
+# AUTOPILOT-004 handoff: CI import repair
+
+## Task
+Investigate the failed Elysia Autopilot CI run for the dry-run dispatcher/ledger integration branch and repair only the bounded collection failure.
+
+## Evidence
+GitHub Actions run `34122102402` reached Python compilation and JSON validation successfully, then failed during pytest collection. The failure was isolated to `autopilot/test_completion_validator.py`, where a relative import (`from .completion_validator ...`) was collected without a known parent package.
+
+## Change
+Replaced the relative import with the repository-root absolute package import:
+`from elysia_collective_seed.autopilot.completion_validator import validate_completion`.
+
+No runtime code, provider invocation, network behavior, authority gates, ledger semantics, dispatcher behavior, or Guardian integration was changed.
+
+## Verification state
+Static diagnosis is complete. The new commit must pass Elysia Autopilot CI before the dry-run dispatcher/ledger integration is considered executable-verification complete.
+
+## Next role
+Independent verifier / CI observer.
+
+## Next task
+Confirm CI on the repaired head. If green, review completion-validation integration and then proceed to the next bounded AUTOPILOT-004 slice. If red, inspect the first failing test and repair only within the existing approved scope.

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000001-completion.json
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000001-completion.json
@@ -1,0 +1,70 @@
+{
+  "task_id": "ELY-TASK-000001",
+  "worker": {
+    "provider": "chatgpt",
+    "role": "autopilot-supervisor",
+    "model": null,
+    "run_id": null
+  },
+  "outcome": "completed",
+  "summary": "Added a runtime-disabled deterministic dispatcher foundation for AUTOPILOT-004. It performs dependency/risk/attempt gating, capability-based worker selection, and bounded follow-up validation without invoking any provider or project runtime.",
+  "files_read": [
+    "elysia_collective_seed/autopilot/orchestrator_spec.md",
+    "elysia_collective_seed/autopilot/task_packet_schema.json",
+    "elysia_collective_seed/autopilot/completion_packet_schema.json"
+  ],
+  "files_changed": [
+    "elysia_collective_seed/autopilot/dispatcher.py",
+    "elysia_collective_seed/autopilot/test_dispatcher.py",
+    "elysia_collective_seed/autopilot/handoffs/ELY-TASK-000001-completion.json"
+  ],
+  "commits": [
+    "24bd1b2953451fc51a974655592c643812408f0e",
+    "cd302d29ff54b0b5a7fd2360b7184d6cef7f0f28"
+  ],
+  "pull_requests": [],
+  "claims": [
+    {
+      "claim": "Protected risk classes and explicit human-approval tasks cannot be dispatched automatically by this module.",
+      "evidence": ["dispatcher.py: dispatch authority gate"],
+      "confidence": 0.99
+    },
+    {
+      "claim": "Follow-up validation rejects source-scope expansion and duplicate open-task titles.",
+      "evidence": ["dispatcher.py: validate_followup", "test_dispatcher.py"],
+      "confidence": 0.99
+    }
+  ],
+  "checks": [
+    {
+      "name": "static design review",
+      "result": "pass",
+      "details": "Module has no provider invocation, subprocess, network, merge, deployment, or Guardian runtime import path."
+    },
+    {
+      "name": "tests committed",
+      "result": "pass",
+      "details": "Seven deterministic tests cover routing, dependency gate, protected risk gate, attempt limit, scope expansion, duplicate follow-up, and valid follow-up. Tests require execution by CI/independent verifier."
+    },
+    {
+      "name": "test execution",
+      "result": "not_run",
+      "details": "GitHub connector can write repository files but does not execute branch tests in this supervisor run."
+    }
+  ],
+  "uncertainties": [
+    "Task schema does not yet declare required_capabilities, although dispatcher tolerates it as an optional extension. Schema alignment should be reviewed before integration.",
+    "Worker scoring is intentionally minimal until outcome-history/calibration data exists."
+  ],
+  "risks": [
+    "This is only the deterministic selection core; leases, persistence, GitHub synchronization, completion validation, and real provider adapters remain unimplemented."
+  ],
+  "blockers": [],
+  "next_recommendation": {
+    "action": "verify",
+    "preferred_role": "guardian-verifier",
+    "task_title": "Verify AUTOPILOT-004 dispatcher foundation",
+    "task_objective": "Run tests and independently review dispatcher gates before extending it with persistent ledger and leases."
+  },
+  "completed_at": "2026-09-07T05:21:15Z"
+}

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000002-verification.json
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000002-verification.json
@@ -1,0 +1,75 @@
+{
+  "task_id": "ELY-TASK-000002",
+  "worker": {
+    "provider": "chatgpt",
+    "role": "guardian-verifier",
+    "model": null,
+    "run_id": null
+  },
+  "outcome": "partial",
+  "summary": "Independently reviewed the AUTOPILOT-004 dispatcher foundation. The authority, dependency, retry, capability, and follow-up gates are structurally bounded and contain no provider/runtime invocation. Verification found one concrete schema mismatch: dispatcher.py consumes optional required_capabilities while task_packet_schema.json previously rejected that field because additionalProperties=false. The schema was corrected and regression tests were added. Execution verification remains pending because no CI status/check is currently reported for the branch head.",
+  "files_read": [
+    "elysia_collective_seed/autopilot/dispatcher.py",
+    "elysia_collective_seed/autopilot/test_dispatcher.py",
+    "elysia_collective_seed/autopilot/task_packet_schema.json",
+    "elysia_collective_seed/autopilot/completion_packet_schema.json",
+    "elysia_collective_seed/autopilot/handoffs/ELY-TASK-000001-completion.json"
+  ],
+  "files_changed": [
+    "elysia_collective_seed/autopilot/task_packet_schema.json",
+    "elysia_collective_seed/autopilot/test_task_schema_alignment.py",
+    "elysia_collective_seed/autopilot/handoffs/ELY-TASK-000002-verification.json"
+  ],
+  "commits": [
+    "87881d9d2f052b8cdce9be1498e4098fd7365174",
+    "1cec1b6d3e1585e9a527dd408cc92adb153323da"
+  ],
+  "pull_requests": ["#12"],
+  "claims": [
+    {
+      "claim": "The dispatcher does not invoke providers, execute Guardian runtime code, merge, deploy, or access credentials.",
+      "evidence": ["PR #12 dispatcher.py static review"],
+      "confidence": 0.99
+    },
+    {
+      "claim": "The task schema now explicitly permits required_capabilities used by dispatcher capability routing.",
+      "evidence": ["task_packet_schema.json", "test_task_schema_alignment.py"],
+      "confidence": 0.99
+    }
+  ],
+  "checks": [
+    {
+      "name": "independent static review",
+      "result": "pass",
+      "details": "Reviewed PR #12 patch independently of the implementation handoff. No external/provider/runtime execution path is present."
+    },
+    {
+      "name": "schema-dispatcher alignment",
+      "result": "pass",
+      "details": "Found and repaired required_capabilities schema mismatch; added two regression tests."
+    },
+    {
+      "name": "CI execution evidence",
+      "result": "not_run",
+      "details": "GitHub reports no status checks for the current branch head, so test execution cannot yet be claimed."
+    }
+  ],
+  "uncertainties": [
+    "Worker quality/cost values are not yet calibrated from outcome history.",
+    "Task-class-as-required-capability is a deliberate simplification that may need separation once the worker registry matures."
+  ],
+  "risks": [
+    "PR #12 must remain draft until executable test evidence exists.",
+    "Persistent claims/leases and completion validation are not yet implemented."
+  ],
+  "blockers": [
+    "No GitHub CI/status check is currently reported for branch head; executable verification remains unavailable from the connected GitHub interface."
+  ],
+  "next_recommendation": {
+    "action": "continue",
+    "preferred_role": "engineer",
+    "task_title": "Add runtime-disabled persistent task ledger and claim leases",
+    "task_objective": "Implement deterministic local persistence and lease semantics with tests, without provider invocation or Guardian runtime wiring."
+  },
+  "completed_at": "2026-09-07T07:35:00Z"
+}

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000003-ledger.json
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000003-ledger.json
@@ -1,0 +1,35 @@
+{
+  "task_id": "ELY-TASK-000003",
+  "parent_issue": 8,
+  "role": "engineer",
+  "status": "completed_pending_verification",
+  "summary": "Implemented a runtime-disabled SQLite task ledger with auditable events and bounded claim/lease semantics so multiple workers cannot silently claim the same task.",
+  "files_changed": [
+    "elysia_collective_seed/autopilot/task_ledger.py",
+    "elysia_collective_seed/autopilot/test_task_ledger.py"
+  ],
+  "evidence": [
+    "TaskLedger persists task payload/status/attempt/claim/lease state in SQLite.",
+    "Claim rejects active leases held by another worker.",
+    "Same-worker renewal extends a lease without incrementing attempts.",
+    "Expired leases can be deterministically reaped and reclaimed.",
+    "Release requires the current lease owner.",
+    "Terminal tasks cannot be claimed.",
+    "Every mutation appends an auditable event record."
+  ],
+  "tests_added": 6,
+  "execution_evidence": "pending CI or independent local execution",
+  "safety": {
+    "provider_invocation": false,
+    "network": false,
+    "subprocess": false,
+    "guardian_runtime_wiring": false,
+    "merge_or_deploy": false
+  },
+  "uncertainties": [
+    "SQLite concurrency behavior should be independently stress-tested before multi-process workers use the ledger.",
+    "Completion-packet validation and verifier-state transitions are not yet wired into the ledger."
+  ],
+  "next_role": "verifier",
+  "next_task": "Independently inspect and execute the task-ledger tests; probe lease expiry, ownership, transaction/concurrency behavior, and schema compatibility before extending dispatcher integration."
+}

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000004-ledger-verification.json
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000004-ledger-verification.json
@@ -1,0 +1,70 @@
+{
+  "task_id": "ELY-TASK-000004",
+  "parent_issue": 8,
+  "role": "guardian-verifier",
+  "status": "partial_pending_execution",
+  "summary": "Independent static verification of the persistent task ledger found two correctness hazards: the original claim path used a read-then-write sequence that was not a safe multi-connection claim primitive, and stale put_task input could reopen a terminal task. The ledger was repaired so renewal and acquisition use conditional atomic UPDATE predicates, stale upserts preserve terminal states, release/reap mutations use ownership/version predicates, and regression coverage now includes independent SQLite connections, same-worker expired reacquisition, and terminal-state preservation.",
+  "defects_found": [
+    {
+      "severity": "high",
+      "defect": "Lease acquisition used SELECT followed by unconditional UPDATE; independent connections could both observe an available task before serialized writes.",
+      "resolution": "Acquisition eligibility is now part of a conditional UPDATE. Renewal is a separate conditional UPDATE and never increments attempts."
+    },
+    {
+      "severity": "high",
+      "defect": "put_task preserved active lease states but not terminal states, so stale queued input could reopen completed/rejected/archived work.",
+      "resolution": "Upsert now preserves active and terminal ledger states."
+    },
+    {
+      "severity": "medium",
+      "defect": "Reap/release used read-then-write ownership assumptions.",
+      "resolution": "Release and reap writes now include current owner/lease predicates and only emit events after a successful row update."
+    }
+  ],
+  "files_changed": [
+    "elysia_collective_seed/autopilot/task_ledger.py",
+    "elysia_collective_seed/autopilot/test_task_ledger.py",
+    "elysia_collective_seed/autopilot/handoffs/ELY-TASK-000004-ledger-verification.json"
+  ],
+  "commits": [
+    "b808886cf04390eb60f1708ca2a83da70e98a3b9",
+    "7c59776864a8dcaced78d92eedfb2a4f04568408",
+    "a60e2bb429ef1407b9b379ffedd32e1899e01af2"
+  ],
+  "checks": [
+    {
+      "name": "independent static concurrency review",
+      "result": "pass_after_repair",
+      "details": "Claim acquisition is now a conditional SQLite UPDATE whose eligibility is checked at write time."
+    },
+    {
+      "name": "terminal-state monotonicity review",
+      "result": "pass_after_repair",
+      "details": "Stale upserts cannot transition completed/rejected/archived tasks back to queued."
+    },
+    {
+      "name": "regression tests committed",
+      "result": "pass",
+      "details": "Added coverage for two independent ledger connections, expired same-worker reacquisition as a new attempt, and stale terminal upserts."
+    },
+    {
+      "name": "test execution",
+      "result": "not_run",
+      "details": "Executable CI/local test evidence is still required before the ledger is integration-ready."
+    }
+  ],
+  "safety": {
+    "provider_invocation": false,
+    "network": false,
+    "subprocess": false,
+    "guardian_runtime_wiring": false,
+    "merge_or_deploy": false
+  },
+  "next_recommendation": {
+    "action": "verify_execution_then_continue",
+    "preferred_role": "guardian-verifier",
+    "task_title": "Execute AUTOPILOT-004 ledger tests and then wire dispatcher-to-ledger claim flow",
+    "task_objective": "Obtain executable test evidence for dispatcher and ledger. If green, add a runtime-disabled orchestration service that dispatches and atomically claims a selected task without invoking any provider."
+  },
+  "completed_at": "2026-09-07T09:21:00Z"
+}

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000005-ci-verification.json
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000005-ci-verification.json
@@ -1,0 +1,63 @@
+{
+  "task_id": "ELY-TASK-000005",
+  "worker": {
+    "provider": "chatgpt",
+    "role": "guardian-verifier",
+    "model": null,
+    "run_id": null
+  },
+  "outcome": "completed",
+  "summary": "Verified executable GitHub Actions evidence for the current AUTOPILOT-004 branch head. Elysia Autopilot CI run 34105729192 completed successfully for head a37ad0d8f839ab3935e02d2d24f894638eef7914. The seed-validation job passed checkout, Python setup, compilation, JSON parsing, the full Elysia Collective seed test invocation, and the runtime-enable safety gate.",
+  "files_read": [
+    "GitHub Actions run 34105729192",
+    "PR #12 current head a37ad0d8f839ab3935e02d2d24f894638eef7914"
+  ],
+  "files_changed": [
+    "elysia_collective_seed/autopilot/handoffs/ELY-TASK-000005-ci-verification.json"
+  ],
+  "commits": [],
+  "pull_requests": ["#12"],
+  "claims": [
+    {
+      "claim": "Executable CI completed successfully for the pre-verification PR #12 branch head a37ad0d8f839ab3935e02d2d24f894638eef7914.",
+      "evidence": ["GitHub Actions run 34105729192: conclusion=success"],
+      "confidence": 1.0
+    },
+    {
+      "claim": "The CI seed-validation job executed and passed the Elysia Collective seed tests and runtime-disable safety gate.",
+      "evidence": ["GitHub Actions job 101690177370 steps 5-8 all conclusion=success"],
+      "confidence": 1.0
+    }
+  ],
+  "checks": [
+    {
+      "name": "GitHub Actions executable verification",
+      "result": "pass",
+      "details": "Workflow Elysia Autopilot CI run 34105729192 completed successfully on branch head a37ad0d8f839ab3935e02d2d24f894638eef7914."
+    },
+    {
+      "name": "test step",
+      "result": "pass",
+      "details": "Run Elysia Collective seed tests completed successfully in job 101690177370."
+    },
+    {
+      "name": "runtime-disable safety gate",
+      "result": "pass",
+      "details": "Enforce no runtime-enable flag in seed prompt pack completed successfully."
+    }
+  ],
+  "uncertainties": [
+    "This evidence applies to head a37ad0d8f839ab3935e02d2d24f894638eef7914 before this evidence-only handoff commit. The handoff itself does not alter executable code, but the new head should receive its own CI run before any later integration decision."
+  ],
+  "risks": [
+    "PR #12 remains intentionally draft and must not be merged into main; provider invocation and Guardian runtime wiring remain outside this verification."
+  ],
+  "blockers": [],
+  "next_recommendation": {
+    "action": "continue",
+    "preferred_role": "engineer",
+    "task_title": "Wire dispatcher decisions to persistent ledger in dry-run mode",
+    "task_objective": "Add a runtime-disabled orchestration service that atomically dispatches eligible tasks into leases and validates completion transitions without invoking external providers."
+  },
+  "completed_at": "2026-09-07T10:21:33Z"
+}

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000006-dryrun-orchestration.json
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000006-dryrun-orchestration.json
@@ -1,0 +1,32 @@
+{
+  "task_id": "ELY-TASK-000006",
+  "status": "implemented_pending_verification",
+  "summary": "Connected the deterministic dispatcher to the persistent SQLite task ledger in provider-free dry-run mode. Eligible work is persisted, re-read from authoritative ledger state, dispatched, and atomically leased to the selected worker without invoking any provider or Guardian runtime.",
+  "files_changed": [
+    "elysia_collective_seed/autopilot/dryrun_orchestrator.py",
+    "elysia_collective_seed/autopilot/test_dryrun_orchestrator.py",
+    "elysia_collective_seed/autopilot/handoffs/ELY-TASK-000006-dryrun-orchestration.json"
+  ],
+  "verification_added": [
+    "happy-path dispatch and lease",
+    "human approval gate prevents claim",
+    "incomplete dependencies prevent claim",
+    "existing active lease cannot be stolen",
+    "stale queued payload cannot reopen completed task"
+  ],
+  "safety": {
+    "provider_invocation": false,
+    "network_execution": false,
+    "subprocess_execution": false,
+    "guardian_runtime_execution": false,
+    "merge_or_deployment": false,
+    "external_write": false
+  },
+  "evidence": [
+    "GitHub Actions previously passed on parent head 781d87fd3b17f7e1cbb0c35f7a863a1a6860b442.",
+    "New orchestration code requires CI on its new head before it can be considered verified."
+  ],
+  "next_role": "independent_verifier",
+  "next_task": "Review dispatcher-ledger integration for stale-state, attempt-limit, lease ownership, concurrency, and schema/interface defects; confirm CI on the new head before any provider adapter work.",
+  "human_approval_required": false
+}

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000007-completion-validation.json
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000007-completion-validation.json
@@ -1,0 +1,60 @@
+{
+  "task_id": "ELY-TASK-000007",
+  "worker": {
+    "provider": "chatgpt",
+    "role": "autopilot-supervisor",
+    "model": null,
+    "run_id": null
+  },
+  "outcome": "completed",
+  "summary": "Added a side-effect-free semantic validator for provider-neutral completion packets before any future ledger state transition. It verifies task identity, worker attribution, outcome/action vocabulary, check uniqueness, required-check presence/pass state, and prevents a completed outcome from carrying explicit failed checks.",
+  "files_read": [
+    "elysia_collective_seed/autopilot/completion_packet_schema.json",
+    "elysia_collective_seed/autopilot/dryrun_orchestrator.py",
+    "elysia_collective_seed/autopilot/task_ledger.py"
+  ],
+  "files_changed": [
+    "elysia_collective_seed/autopilot/completion_validator.py",
+    "elysia_collective_seed/autopilot/test_completion_validator.py",
+    "elysia_collective_seed/autopilot/handoffs/ELY-TASK-000007-completion-validation.json"
+  ],
+  "commits": [
+    "b0f6ed7a1f59dce36e88d2c9f2b1a8e701427d3e",
+    "e891abb6ed39c7a55a0743e43cfef5b426cd8cf8"
+  ],
+  "pull_requests": ["#12"],
+  "claims": [
+    {
+      "claim": "Completion validation remains provider-neutral, runtime-disabled, and side-effect free.",
+      "evidence": ["elysia_collective_seed/autopilot/completion_validator.py"],
+      "confidence": 0.99
+    },
+    {
+      "claim": "Regression tests cover identity mismatch, missing/nonpassing required checks, failed completed outcomes, duplicate checks, and valid partial failure reporting.",
+      "evidence": ["elysia_collective_seed/autopilot/test_completion_validator.py"],
+      "confidence": 0.99
+    }
+  ],
+  "checks": [
+    {
+      "name": "static_safety_scope",
+      "result": "pass",
+      "details": "No provider invocation, subprocess, network, GitHub mutation, Guardian runtime invocation, merge, or deployment code was added."
+    },
+    {
+      "name": "executable_ci",
+      "result": "not_run",
+      "details": "New branch head requires GitHub Actions execution and independent verification."
+    }
+  ],
+  "uncertainties": ["Independent execution has not yet verified the new tests."],
+  "risks": ["Semantic validation is intentionally not yet wired to mutate ledger state; premature integration would bypass the next verification gate."],
+  "blockers": [],
+  "next_recommendation": {
+    "action": "verify",
+    "preferred_role": "guardian-verifier",
+    "task_title": "Verify completion packet validator and CI",
+    "task_objective": "Independently review completion semantics and confirm the new branch head passes executable CI before connecting validated completions to ledger state transitions."
+  },
+  "completed_at": "2026-09-07T12:27:54Z"
+}

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000009-test-discovery-verification.json
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000009-test-discovery-verification.json
@@ -1,0 +1,67 @@
+{
+  "task_id": "ELY-TASK-000009",
+  "worker": {
+    "provider": "chatgpt",
+    "role": "guardian-verifier",
+    "model": null,
+    "run_id": null
+  },
+  "outcome": "completed",
+  "summary": "Independent static verification found that the task-state policy regression file was named task_state_machine_tests.py, which does not match pytest's default test_*.py discovery pattern used by Elysia Autopilot CI. Added a pytest-discoverable test_task_state_machine.py containing the policy coverage plus terminal/unknown-state regressions. The original evidence file was preserved; no runtime or provider behavior was enabled.",
+  "files_read": [
+    ".github/workflows/elysia-autopilot-ci.yml",
+    "elysia_collective_seed/autopilot/task_state_machine.py",
+    "elysia_collective_seed/autopilot/task_state_machine_tests.py",
+    "elysia_collective_seed/autopilot/completion_validator.py",
+    "elysia_collective_seed/autopilot/test_completion_validator.py"
+  ],
+  "files_changed": [
+    "elysia_collective_seed/autopilot/test_task_state_machine.py",
+    "elysia_collective_seed/autopilot/handoffs/ELY-TASK-000009-test-discovery-verification.json"
+  ],
+  "commits": [
+    "7010ca75d69384797ba435561957decc0def18f6"
+  ],
+  "pull_requests": ["#12"],
+  "claims": [
+    {
+      "claim": "The state-policy tests now match pytest's default test_*.py collection pattern used by the CI workflow.",
+      "evidence": [
+        ".github/workflows/elysia-autopilot-ci.yml",
+        "elysia_collective_seed/autopilot/test_task_state_machine.py"
+      ],
+      "confidence": 1.0
+    },
+    {
+      "claim": "No runtime activation, provider invocation, network adapter, merge, deployment, or authority expansion was introduced.",
+      "evidence": ["elysia_collective_seed/autopilot/test_task_state_machine.py"],
+      "confidence": 1.0
+    }
+  ],
+  "checks": [
+    {
+      "name": "static_test_discovery_review",
+      "result": "pass",
+      "details": "CI invokes `python -m pytest -q elysia_collective_seed`; the new filename begins with test_ and is therefore discoverable under pytest defaults."
+    },
+    {
+      "name": "executable_ci",
+      "result": "not_run",
+      "details": "The new branch head must pass GitHub Actions before this verification is treated as executable evidence."
+    }
+  ],
+  "uncertainties": [
+    "GitHub Actions result for the new branch head was not yet available at handoff creation."
+  ],
+  "risks": [
+    "The older task_state_machine_tests.py remains as historical implementation evidence but is not relied upon for CI collection."
+  ],
+  "blockers": [],
+  "next_recommendation": {
+    "action": "verify",
+    "preferred_role": "guardian-verifier",
+    "task_title": "Verify CI on pytest-discovery repair",
+    "task_objective": "Confirm the new branch head passes Elysia Autopilot CI and that test_task_state_machine.py is collected before wiring completion validation to persistent ledger transitions."
+  },
+  "completed_at": "2026-09-07T14:22:39Z"
+}

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000010-completion-ledger-integration.json
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000010-completion-ledger-integration.json
@@ -1,0 +1,20 @@
+{
+  "task_id": "ELY-TASK-000010",
+  "worker": {"provider": "chatgpt", "role": "engineer"},
+  "outcome": "completed",
+  "summary": "Connected semantic completion validation to persistent ledger transitions in provider-free dry-run orchestration. Worker-reported completed work now enters verifying rather than completed; invalid or non-owner completion packets cannot mutate task state; partial/failed work returns to queue; blocked/rejected outcomes map to bounded states.",
+  "checks": [
+    {"name": "static_scope", "result": "pass"},
+    {"name": "provider_invocation", "result": "pass"},
+    {"name": "runtime_enablement", "result": "pass"},
+    {"name": "ci_new_head", "result": "not_run"}
+  ],
+  "evidence": [
+    "elysia_collective_seed/autopilot/dryrun_orchestrator.py",
+    "elysia_collective_seed/autopilot/test_dryrun_orchestrator.py"
+  ],
+  "next_recommendation": {
+    "action": "verify",
+    "summary": "Independently inspect the completion-to-ledger state policy and require CI success on the new branch head before expanding orchestration."
+  }
+}

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000011-ci-failure-repair.md
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000011-ci-failure-repair.md
@@ -1,0 +1,27 @@
+# ELY-TASK-000011 — CI failure diagnosis and repair
+
+## Scope
+Independent supervisor verification of AUTOPILOT-004 completion-to-ledger integration after CI run 34138632289 failed in the seed test step.
+
+## Finding
+The new completion path intentionally maps a producer `completed` packet to `verifying`, then releases the producer lease. `TaskLedger.release()` rejected `verifying` because it was classified as an active lease state. This made the independent-verification handoff impossible and caused the newly collected orchestration test to fail.
+
+A second state-safety issue was repaired at the same boundary: `claim()` previously allowed acquisition from any non-terminal state. That could permit a review/verifying/blocked task to be leased again without an explicit gate transition.
+
+## Repair
+- Active execution lease states are now only `claimed` and `running`.
+- `verifying`/`review` remain persisted non-dispatchable states but may exist without the producer lease.
+- New lease acquisition is atomically restricted to `status='queued'`.
+- Lease renewal is restricted to active execution states.
+- Expiry reaping is restricted to active execution states.
+- Non-queued, non-terminal claims return `state_not_claimable` rather than silently acquiring.
+
+## Safety
+No provider invocation, Guardian runtime wiring, network/subprocess execution, merge, deployment, external posting, credential access, or private-data scope was added. PR #12 remains draft and targets the isolated Elysia Collective seed branch.
+
+## Evidence
+- Failed workflow: GitHub Actions run 34138632289, seed test step failed while compile and JSON validation passed.
+- Repair commit: c406a0dbf8163c43b1275dcba0bfdcf0d1bd9fd7.
+
+## Handoff / gate
+Wait for CI on the repaired branch head. If green, independently verify the completion-to-`verifying` transition and queued-only claim invariant before adding verifier-result application. Do not merge or enable runtime/provider adapters.

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000012-active-lease-ci-repair.md
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000012-active-lease-ci-repair.md
@@ -1,0 +1,22 @@
+# ELY-TASK-000012 — active-lease CI repair
+
+## Scope
+Diagnose the remaining AUTOPILOT-004 seed-test failure without expanding runtime or provider authority.
+
+## Finding
+The dry-run regression `test_existing_active_lease_is_not_stolen` expects a competing worker to receive `active_lease`. After the queued-only acquisition hardening, `TaskLedger.claim()` instead returned the generic `state_not_claimable` for a live `claimed`/`running` lease owned by another worker. The task remained protected, but the observable conflict contract no longer matched the regression/API semantics.
+
+## Repair
+Preserve queued-only acquisition and explicitly classify a live lease in `claimed`/`running` as `active_lease` after atomic acquisition fails. Review/verifying/blocked/human-review states continue to return `state_not_claimable`; terminal states remain `terminal_task`.
+
+## Safety
+No provider invocation, Guardian runtime activation, networking, external posting, merge, deployment, private-data expansion, or safety/audit/rollback weakening was introduced.
+
+## Evidence
+- repaired: `elysia_collective_seed/autopilot/task_ledger.py`
+- existing regression: `elysia_collective_seed/autopilot/test_dryrun_orchestrator.py::test_existing_active_lease_is_not_stolen`
+- prior failing workflow: GitHub Actions run 34142894909, seed-validation step 7
+- repair commit: 2ada6c0d021978539eba77e072a279e5252e6f0a
+
+## Handoff / gate
+Keep PR #12 draft and unmerged. Require executable CI on the new branch head before treating this repair as verified. If CI still fails, inspect the next concrete failing assertion and repair only that bounded defect before adding orchestration capability.

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000013-expired-lease-ci-repair.md
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000013-expired-lease-ci-repair.md
@@ -1,0 +1,23 @@
+# ELY-TASK-000013 — expired-lease CI repair
+
+## Scope
+Diagnose the next bounded AUTOPILOT-004 seed-test failure after the active-lease conflict repair, without expanding runtime/provider authority.
+
+## Finding
+`test_same_worker_reacquires_expired_lease_as_new_attempt` requires an expired execution lease to be reclaimable as a new attempt. `TaskLedger.claim()` only acquired rows whose persisted status was `queued`, so an expired `claimed`/`running` row could not be reclaimed unless a separate `reap_expired()` call happened first. That contradicted the existing regression and left claim semantics dependent on an external cleanup race.
+
+## Repair
+The atomic acquisition UPDATE now permits either (a) eligible queued work or (b) an expired `claimed`/`running` execution lease. Live leases remain protected, and `verifying`, `review`, `blocked`, `human_review`, and terminal states remain non-claimable. Reclaim increments `attempt` exactly once.
+
+## Evidence
+- repaired file: `elysia_collective_seed/autopilot/task_ledger.py`
+- regression: `elysia_collective_seed/autopilot/test_task_ledger.py::test_same_worker_reacquires_expired_lease_as_new_attempt`
+- prior failing head: `5ffe2c3fd30a198b3b3384ab00738e8ab2a1584a`
+- prior workflow: GitHub Actions run `34151581011`, failing at seed-test step 7
+- repair commit: `3c1f995d3b856dd3db2e70b69c4026ae570067dd`
+
+## Safety
+No provider invocation, Guardian runtime activation, networking, external posting, merge, deployment, private-data expansion, or safety/audit/rollback weakening was introduced.
+
+## Handoff / gate
+Keep PR #12 draft and unmerged. Require executable CI on the new branch head before treating this repair as verified. If CI still fails, diagnose only the next concrete assertion before adding orchestration capability.

--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000014-schema-state-alignment.md
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000014-schema-state-alignment.md
@@ -1,0 +1,22 @@
+# ELY-TASK-000014 — Task schema/runtime state alignment
+
+## Objective
+Keep the provider-neutral task packet contract aligned with the runtime ledger state machine without enabling runtime providers or Guardian execution.
+
+## Finding
+The AUTOPILOT-004 ledger treats `verifying` and `human_review` as explicit non-dispatchable control states, but the task packet JSON Schema did not permit those values. That allowed runtime state to diverge from the durable interchange contract.
+
+## Changes
+- Added `verifying` and `human_review` to `task_packet_schema.json` status enum.
+- Added a regression assertion that all current runtime control states are declared by the schema.
+
+## Safety
+Schema/test-only change on isolated branch `autopilot-004-schema-state-alignment`. No provider invocation, Guardian runtime wiring, network/subprocess execution, deployment, external posting, credential access, or merge.
+
+## Evidence
+- Source ledger: `elysia_collective_seed/autopilot/task_ledger.py` defines `verifying` and `human_review` as non-dispatchable states.
+- Contract: `elysia_collective_seed/autopilot/task_packet_schema.json` now admits both states.
+- Regression: `elysia_collective_seed/autopilot/test_task_schema_alignment.py::test_task_schema_declares_runtime_control_states`.
+
+## Handoff
+Independent verification should run the existing AUTOPILOT CI/test suite on this branch. If green, this bounded repair can be incorporated into the AUTOPILOT-004 draft branch without changing its draft/unmerged integration gate.

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -110,11 +110,12 @@ class TaskLedger:
         return result
 
     def claim(self, task_id: str, worker_id: str, lease_seconds: int = 900, now: datetime | None = None) -> ClaimResult:
-        """Atomically renew an owned live lease or acquire a queued task.
+        """Atomically renew an owned live lease or acquire eligible execution work.
 
-        Acquisition is deliberately queued-only. Review/verifying/blocked states
-        require an explicit state transition before another execution lease may be
-        granted, preventing a stale caller from silently bypassing those gates.
+        Fresh acquisition is queued-only. An expired claimed/running lease may be
+        atomically reclaimed as a new attempt without first requiring a separate
+        reap transaction. Review/verifying/blocked states still require an explicit
+        transition before another execution lease may be granted.
         """
         if lease_seconds <= 0:
             raise ValueError("lease_seconds must be positive")
@@ -137,9 +138,11 @@ class TaskLedger:
             acquired = self.conn.execute(
                 """UPDATE tasks
                    SET status='claimed', attempt=attempt+1, claimed_by=?, lease_expires_at=?, updated_at=?
-                   WHERE task_id=? AND status='queued'
-                     AND (claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=?)""",
-                (worker_id, expires, now_s, task_id, now_s),
+                   WHERE task_id=? AND (
+                     (status='queued' AND (claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=?))
+                     OR (status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at<=?)
+                   )""",
+                (worker_id, expires, now_s, task_id, now_s, now_s),
             )
             if acquired.rowcount == 1:
                 self._event(task_id, "task_claimed", worker_id, {"expires": expires}, now_s)

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -109,14 +109,7 @@ class TaskLedger:
         return result
 
     def claim(self, task_id: str, worker_id: str, lease_seconds: int = 900, now: datetime | None = None) -> ClaimResult:
-        """Atomically claim or renew a task lease.
-
-        The eligibility predicate is part of the UPDATE itself. This is important:
-        a read-then-write claim can allow two independent SQLite connections to
-        observe an unclaimed row before either writes it. SQLite serializes the
-        conditional UPDATE, so only a worker that still satisfies the predicate
-        at write time can acquire the lease.
-        """
+        """Atomically renew an owned live lease or acquire an available lease."""
         if lease_seconds <= 0:
             raise ValueError("lease_seconds must be positive")
         now = now or _utcnow()
@@ -125,30 +118,33 @@ class TaskLedger:
         terminal = tuple(sorted(TERMINAL_STATES))
 
         with self.conn:
-            cursor = self.conn.execute(
+            # Renewal is a separate conditional write so it never increments the
+            # attempt counter and cannot be confused with an expired reacquisition.
+            renewed = self.conn.execute(
+                """UPDATE tasks SET status='claimed', lease_expires_at=?, updated_at=?
+                   WHERE task_id=? AND claimed_by=?
+                     AND lease_expires_at IS NOT NULL AND lease_expires_at>?
+                     AND status NOT IN (?,?,?)""",
+                (expires, now_s, task_id, worker_id, now_s, terminal[0], terminal[1], terminal[2]),
+            )
+            if renewed.rowcount == 1:
+                self._event(task_id, "lease_renewed", worker_id, {"expires": expires}, now_s)
+                return ClaimResult(True, task_id, worker_id, "renewed", expires)
+
+            # Acquisition eligibility is inside the UPDATE. Two independent
+            # connections cannot both acquire the same available row: after one
+            # serialized write succeeds, the other's predicate no longer matches.
+            acquired = self.conn.execute(
                 """UPDATE tasks
-                   SET status='claimed',
-                       attempt=attempt + CASE
-                           WHEN claimed_by=? AND lease_expires_at IS NOT NULL AND lease_expires_at>? THEN 0
-                           ELSE 1 END,
-                       claimed_by=?, lease_expires_at=?, updated_at=?
+                   SET status='claimed', attempt=attempt+1, claimed_by=?, lease_expires_at=?, updated_at=?
                    WHERE task_id=?
                      AND status NOT IN (?,?,?)
-                     AND (
-                         claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=? OR claimed_by=?
-                     )""",
-                (
-                    worker_id, now_s, worker_id, expires, now_s, task_id,
-                    terminal[0], terminal[1], terminal[2], now_s, worker_id,
-                ),
+                     AND (claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=?)""",
+                (worker_id, expires, now_s, task_id, terminal[0], terminal[1], terminal[2], now_s),
             )
-            if cursor.rowcount == 1:
-                row = self.conn.execute(
-                    "SELECT attempt FROM tasks WHERE task_id=?", (task_id,)
-                ).fetchone()
-                event_type = "lease_renewed" if row and int(row["attempt"]) > 0 and self._last_claim_actor(task_id) == worker_id else "task_claimed"
-                self._event(task_id, event_type, worker_id, {"expires": expires}, now_s)
-                return ClaimResult(True, task_id, worker_id, "renewed" if event_type == "lease_renewed" else "claimed", expires)
+            if acquired.rowcount == 1:
+                self._event(task_id, "task_claimed", worker_id, {"expires": expires}, now_s)
+                return ClaimResult(True, task_id, worker_id, "claimed", expires)
 
             row = self.conn.execute("SELECT * FROM tasks WHERE task_id=?", (task_id,)).fetchone()
             if not row:
@@ -156,15 +152,6 @@ class TaskLedger:
             if row["status"] in TERMINAL_STATES:
                 return ClaimResult(False, task_id, worker_id, "terminal_task")
             return ClaimResult(False, task_id, worker_id, "active_lease", row["lease_expires_at"])
-
-    def _last_claim_actor(self, task_id: str) -> str | None:
-        row = self.conn.execute(
-            """SELECT actor FROM events
-               WHERE task_id=? AND event_type IN ('task_claimed','lease_renewed')
-               ORDER BY event_id DESC LIMIT 1""",
-            (task_id,),
-        ).fetchone()
-        return row["actor"] if row else None
 
     def release(self, task_id: str, worker_id: str, next_status: str = "queued", now: datetime | None = None) -> bool:
         if next_status in ACTIVE_LEASE_STATES:

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -13,8 +13,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Mapping
 
-ACTIVE_LEASE_STATES = {"claimed", "running", "verifying"}
+ACTIVE_LEASE_STATES = {"claimed", "running"}
 TERMINAL_STATES = {"completed", "rejected", "archived"}
+NON_DISPATCHABLE_STATES = ACTIVE_LEASE_STATES | {"verifying", "review", "blocked", "human_review"} | TERMINAL_STATES
 
 
 def _utcnow() -> datetime:
@@ -88,7 +89,7 @@ class TaskLedger:
                    VALUES(?,?,?,?,?)
                    ON CONFLICT(task_id) DO UPDATE SET
                      payload_json=excluded.payload_json,
-                     status=CASE WHEN tasks.status IN ('claimed','running','verifying','completed','rejected','archived')
+                     status=CASE WHEN tasks.status IN ('claimed','running','verifying','review','blocked','human_review','completed','rejected','archived')
                                  THEN tasks.status ELSE excluded.status END,
                      updated_at=excluded.updated_at""",
                 (task_id, payload, status, int(task.get("attempt", 0)), now),
@@ -109,38 +110,36 @@ class TaskLedger:
         return result
 
     def claim(self, task_id: str, worker_id: str, lease_seconds: int = 900, now: datetime | None = None) -> ClaimResult:
-        """Atomically renew an owned live lease or acquire an available lease."""
+        """Atomically renew an owned live lease or acquire a queued task.
+
+        Acquisition is deliberately queued-only. Review/verifying/blocked states
+        require an explicit state transition before another execution lease may be
+        granted, preventing a stale caller from silently bypassing those gates.
+        """
         if lease_seconds <= 0:
             raise ValueError("lease_seconds must be positive")
         now = now or _utcnow()
         now_s = _iso(now)
         expires = _iso(now + timedelta(seconds=lease_seconds))
-        terminal = tuple(sorted(TERMINAL_STATES))
 
         with self.conn:
-            # Renewal is a separate conditional write so it never increments the
-            # attempt counter and cannot be confused with an expired reacquisition.
             renewed = self.conn.execute(
                 """UPDATE tasks SET status='claimed', lease_expires_at=?, updated_at=?
                    WHERE task_id=? AND claimed_by=?
                      AND lease_expires_at IS NOT NULL AND lease_expires_at>?
-                     AND status NOT IN (?,?,?)""",
-                (expires, now_s, task_id, worker_id, now_s, terminal[0], terminal[1], terminal[2]),
+                     AND status IN ('claimed','running')""",
+                (expires, now_s, task_id, worker_id, now_s),
             )
             if renewed.rowcount == 1:
                 self._event(task_id, "lease_renewed", worker_id, {"expires": expires}, now_s)
                 return ClaimResult(True, task_id, worker_id, "renewed", expires)
 
-            # Acquisition eligibility is inside the UPDATE. Two independent
-            # connections cannot both acquire the same available row: after one
-            # serialized write succeeds, the other's predicate no longer matches.
             acquired = self.conn.execute(
                 """UPDATE tasks
                    SET status='claimed', attempt=attempt+1, claimed_by=?, lease_expires_at=?, updated_at=?
-                   WHERE task_id=?
-                     AND status NOT IN (?,?,?)
+                   WHERE task_id=? AND status='queued'
                      AND (claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=?)""",
-                (worker_id, expires, now_s, task_id, terminal[0], terminal[1], terminal[2], now_s),
+                (worker_id, expires, now_s, task_id, now_s),
             )
             if acquired.rowcount == 1:
                 self._event(task_id, "task_claimed", worker_id, {"expires": expires}, now_s)
@@ -151,6 +150,8 @@ class TaskLedger:
                 return ClaimResult(False, task_id, worker_id, "task_not_found")
             if row["status"] in TERMINAL_STATES:
                 return ClaimResult(False, task_id, worker_id, "terminal_task")
+            if row["status"] != "queued":
+                return ClaimResult(False, task_id, worker_id, "state_not_claimable", row["lease_expires_at"])
             return ClaimResult(False, task_id, worker_id, "active_lease", row["lease_expires_at"])
 
     def release(self, task_id: str, worker_id: str, next_status: str = "queued", now: datetime | None = None) -> bool:
@@ -172,7 +173,7 @@ class TaskLedger:
         now = now or _utcnow()
         now_s = _iso(now)
         rows = self.conn.execute(
-            "SELECT task_id, claimed_by, lease_expires_at FROM tasks WHERE claimed_by IS NOT NULL"
+            "SELECT task_id, claimed_by, lease_expires_at FROM tasks WHERE claimed_by IS NOT NULL AND status IN ('claimed','running')"
         ).fetchall()
         expired = [r for r in rows if (_parse(r["lease_expires_at"]) or now) <= now]
         with self.conn:
@@ -180,7 +181,7 @@ class TaskLedger:
             for row in expired:
                 cursor = self.conn.execute(
                     """UPDATE tasks SET status='queued', claimed_by=NULL, lease_expires_at=NULL, updated_at=?
-                       WHERE task_id=? AND claimed_by=? AND lease_expires_at=?""",
+                       WHERE task_id=? AND claimed_by=? AND lease_expires_at=? AND status IN ('claimed','running')""",
                     (now_s, row["task_id"], row["claimed_by"], row["lease_expires_at"]),
                 )
                 if cursor.rowcount == 1:

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -43,7 +43,7 @@ class TaskLedger:
 
     def __init__(self, path: str | Path):
         self.path = str(path)
-        self.conn = sqlite3.connect(self.path)
+        self.conn = sqlite3.connect(self.path, timeout=5.0)
         self.conn.row_factory = sqlite3.Row
         self.conn.execute("PRAGMA foreign_keys=ON")
         self.conn.execute("PRAGMA journal_mode=WAL")
@@ -88,7 +88,7 @@ class TaskLedger:
                    VALUES(?,?,?,?,?)
                    ON CONFLICT(task_id) DO UPDATE SET
                      payload_json=excluded.payload_json,
-                     status=CASE WHEN tasks.status IN ('claimed','running','verifying')
+                     status=CASE WHEN tasks.status IN ('claimed','running','verifying','completed','rejected','archived')
                                  THEN tasks.status ELSE excluded.status END,
                      updated_at=excluded.updated_at""",
                 (task_id, payload, status, int(task.get("attempt", 0)), now),
@@ -109,48 +109,75 @@ class TaskLedger:
         return result
 
     def claim(self, task_id: str, worker_id: str, lease_seconds: int = 900, now: datetime | None = None) -> ClaimResult:
+        """Atomically claim or renew a task lease.
+
+        The eligibility predicate is part of the UPDATE itself. This is important:
+        a read-then-write claim can allow two independent SQLite connections to
+        observe an unclaimed row before either writes it. SQLite serializes the
+        conditional UPDATE, so only a worker that still satisfies the predicate
+        at write time can acquire the lease.
+        """
         if lease_seconds <= 0:
             raise ValueError("lease_seconds must be positive")
         now = now or _utcnow()
         now_s = _iso(now)
         expires = _iso(now + timedelta(seconds=lease_seconds))
+        terminal = tuple(sorted(TERMINAL_STATES))
+
         with self.conn:
+            cursor = self.conn.execute(
+                """UPDATE tasks
+                   SET status='claimed',
+                       attempt=attempt + CASE
+                           WHEN claimed_by=? AND lease_expires_at IS NOT NULL AND lease_expires_at>? THEN 0
+                           ELSE 1 END,
+                       claimed_by=?, lease_expires_at=?, updated_at=?
+                   WHERE task_id=?
+                     AND status NOT IN (?,?,?)
+                     AND (
+                         claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=? OR claimed_by=?
+                     )""",
+                (
+                    worker_id, now_s, worker_id, expires, now_s, task_id,
+                    terminal[0], terminal[1], terminal[2], now_s, worker_id,
+                ),
+            )
+            if cursor.rowcount == 1:
+                row = self.conn.execute(
+                    "SELECT attempt FROM tasks WHERE task_id=?", (task_id,)
+                ).fetchone()
+                event_type = "lease_renewed" if row and int(row["attempt"]) > 0 and self._last_claim_actor(task_id) == worker_id else "task_claimed"
+                self._event(task_id, event_type, worker_id, {"expires": expires}, now_s)
+                return ClaimResult(True, task_id, worker_id, "renewed" if event_type == "lease_renewed" else "claimed", expires)
+
             row = self.conn.execute("SELECT * FROM tasks WHERE task_id=?", (task_id,)).fetchone()
             if not row:
                 return ClaimResult(False, task_id, worker_id, "task_not_found")
             if row["status"] in TERMINAL_STATES:
                 return ClaimResult(False, task_id, worker_id, "terminal_task")
-            current_expiry = _parse(row["lease_expires_at"])
-            active = row["claimed_by"] and current_expiry and current_expiry > now
-            if active and row["claimed_by"] != worker_id:
-                return ClaimResult(False, task_id, worker_id, "active_lease", row["lease_expires_at"])
-            if active and row["claimed_by"] == worker_id:
-                self.conn.execute(
-                    "UPDATE tasks SET lease_expires_at=?, updated_at=? WHERE task_id=?",
-                    (expires, now_s, task_id),
-                )
-                self._event(task_id, "lease_renewed", worker_id, {"expires": expires}, now_s)
-                return ClaimResult(True, task_id, worker_id, "renewed", expires)
-            self.conn.execute(
-                """UPDATE tasks SET status='claimed', claimed_by=?, lease_expires_at=?,
-                   attempt=attempt+1, updated_at=? WHERE task_id=?""",
-                (worker_id, expires, now_s, task_id),
-            )
-            self._event(task_id, "task_claimed", worker_id, {"expires": expires}, now_s)
-            return ClaimResult(True, task_id, worker_id, "claimed", expires)
+            return ClaimResult(False, task_id, worker_id, "active_lease", row["lease_expires_at"])
+
+    def _last_claim_actor(self, task_id: str) -> str | None:
+        row = self.conn.execute(
+            """SELECT actor FROM events
+               WHERE task_id=? AND event_type IN ('task_claimed','lease_renewed')
+               ORDER BY event_id DESC LIMIT 1""",
+            (task_id,),
+        ).fetchone()
+        return row["actor"] if row else None
 
     def release(self, task_id: str, worker_id: str, next_status: str = "queued", now: datetime | None = None) -> bool:
         if next_status in ACTIVE_LEASE_STATES:
             raise ValueError("release next_status cannot retain an active lease state")
         now_s = _iso(now or _utcnow())
         with self.conn:
-            row = self.conn.execute("SELECT claimed_by FROM tasks WHERE task_id=?", (task_id,)).fetchone()
-            if not row or row["claimed_by"] != worker_id:
-                return False
-            self.conn.execute(
-                "UPDATE tasks SET status=?, claimed_by=NULL, lease_expires_at=NULL, updated_at=? WHERE task_id=?",
-                (next_status, now_s, task_id),
+            cursor = self.conn.execute(
+                """UPDATE tasks SET status=?, claimed_by=NULL, lease_expires_at=NULL, updated_at=?
+                   WHERE task_id=? AND claimed_by=?""",
+                (next_status, now_s, task_id, worker_id),
             )
+            if cursor.rowcount != 1:
+                return False
             self._event(task_id, "task_released", worker_id, {"status": next_status}, now_s)
             return True
 
@@ -162,13 +189,17 @@ class TaskLedger:
         ).fetchall()
         expired = [r for r in rows if (_parse(r["lease_expires_at"]) or now) <= now]
         with self.conn:
+            reaped: list[str] = []
             for row in expired:
-                self.conn.execute(
-                    "UPDATE tasks SET status='queued', claimed_by=NULL, lease_expires_at=NULL, updated_at=? WHERE task_id=?",
-                    (now_s, row["task_id"]),
+                cursor = self.conn.execute(
+                    """UPDATE tasks SET status='queued', claimed_by=NULL, lease_expires_at=NULL, updated_at=?
+                       WHERE task_id=? AND claimed_by=? AND lease_expires_at=?""",
+                    (now_s, row["task_id"], row["claimed_by"], row["lease_expires_at"]),
                 )
-                self._event(row["task_id"], "lease_expired", row["claimed_by"], {}, now_s)
-        return [r["task_id"] for r in expired]
+                if cursor.rowcount == 1:
+                    self._event(row["task_id"], "lease_expired", row["claimed_by"], {}, now_s)
+                    reaped.append(row["task_id"])
+        return reaped
 
     def events(self, task_id: str) -> list[dict]:
         rows = self.conn.execute(

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -150,6 +150,9 @@ class TaskLedger:
                 return ClaimResult(False, task_id, worker_id, "task_not_found")
             if row["status"] in TERMINAL_STATES:
                 return ClaimResult(False, task_id, worker_id, "terminal_task")
+            lease_expiry = _parse(row["lease_expires_at"])
+            if row["status"] in ACTIVE_LEASE_STATES and row["claimed_by"] is not None and lease_expiry is not None and lease_expiry > now:
+                return ClaimResult(False, task_id, worker_id, "active_lease", row["lease_expires_at"])
             if row["status"] != "queued":
                 return ClaimResult(False, task_id, worker_id, "state_not_claimable", row["lease_expires_at"])
             return ClaimResult(False, task_id, worker_id, "active_lease", row["lease_expires_at"])

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -1,0 +1,184 @@
+"""Persistent local task ledger with bounded claim/lease semantics.
+
+Runtime-disabled integration primitive: this module performs only explicit local
+SQLite operations. It does not invoke providers, execute Guardian runtime code,
+use the network, merge branches, or deploy anything.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Mapping
+
+ACTIVE_LEASE_STATES = {"claimed", "running", "verifying"}
+TERMINAL_STATES = {"completed", "rejected", "archived"}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _parse(value: str | None) -> datetime | None:
+    return datetime.fromisoformat(value) if value else None
+
+
+@dataclass(frozen=True)
+class ClaimResult:
+    claimed: bool
+    task_id: str
+    worker_id: str
+    reason: str
+    lease_expires_at: str | None = None
+
+
+class TaskLedger:
+    """Small auditable SQLite ledger suitable for deterministic orchestration tests."""
+
+    def __init__(self, path: str | Path):
+        self.path = str(path)
+        self.conn = sqlite3.connect(self.path)
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA foreign_keys=ON")
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self._init_schema()
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def _init_schema(self) -> None:
+        self.conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS tasks (
+                task_id TEXT PRIMARY KEY,
+                payload_json TEXT NOT NULL,
+                status TEXT NOT NULL,
+                attempt INTEGER NOT NULL DEFAULT 0,
+                claimed_by TEXT,
+                lease_expires_at TEXT,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS events (
+                event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                actor TEXT,
+                detail_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(task_id) REFERENCES tasks(task_id)
+            );
+            """
+        )
+        self.conn.commit()
+
+    def put_task(self, task: Mapping) -> None:
+        task_id = str(task["task_id"])
+        status = str(task.get("status", "queued"))
+        now = _iso(_utcnow())
+        payload = json.dumps(dict(task), sort_keys=True)
+        with self.conn:
+            self.conn.execute(
+                """INSERT INTO tasks(task_id,payload_json,status,attempt,updated_at)
+                   VALUES(?,?,?,?,?)
+                   ON CONFLICT(task_id) DO UPDATE SET
+                     payload_json=excluded.payload_json,
+                     status=CASE WHEN tasks.status IN ('claimed','running','verifying')
+                                 THEN tasks.status ELSE excluded.status END,
+                     updated_at=excluded.updated_at""",
+                (task_id, payload, status, int(task.get("attempt", 0)), now),
+            )
+            self._event(task_id, "task_upserted", "ledger", {"status": status}, now)
+
+    def get(self, task_id: str) -> dict | None:
+        row = self.conn.execute("SELECT * FROM tasks WHERE task_id=?", (task_id,)).fetchone()
+        if not row:
+            return None
+        result = json.loads(row["payload_json"])
+        result.update({
+            "status": row["status"],
+            "attempt": row["attempt"],
+            "claimed_by": row["claimed_by"],
+            "lease_expires_at": row["lease_expires_at"],
+        })
+        return result
+
+    def claim(self, task_id: str, worker_id: str, lease_seconds: int = 900, now: datetime | None = None) -> ClaimResult:
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        now = now or _utcnow()
+        now_s = _iso(now)
+        expires = _iso(now + timedelta(seconds=lease_seconds))
+        with self.conn:
+            row = self.conn.execute("SELECT * FROM tasks WHERE task_id=?", (task_id,)).fetchone()
+            if not row:
+                return ClaimResult(False, task_id, worker_id, "task_not_found")
+            if row["status"] in TERMINAL_STATES:
+                return ClaimResult(False, task_id, worker_id, "terminal_task")
+            current_expiry = _parse(row["lease_expires_at"])
+            active = row["claimed_by"] and current_expiry and current_expiry > now
+            if active and row["claimed_by"] != worker_id:
+                return ClaimResult(False, task_id, worker_id, "active_lease", row["lease_expires_at"])
+            if active and row["claimed_by"] == worker_id:
+                self.conn.execute(
+                    "UPDATE tasks SET lease_expires_at=?, updated_at=? WHERE task_id=?",
+                    (expires, now_s, task_id),
+                )
+                self._event(task_id, "lease_renewed", worker_id, {"expires": expires}, now_s)
+                return ClaimResult(True, task_id, worker_id, "renewed", expires)
+            self.conn.execute(
+                """UPDATE tasks SET status='claimed', claimed_by=?, lease_expires_at=?,
+                   attempt=attempt+1, updated_at=? WHERE task_id=?""",
+                (worker_id, expires, now_s, task_id),
+            )
+            self._event(task_id, "task_claimed", worker_id, {"expires": expires}, now_s)
+            return ClaimResult(True, task_id, worker_id, "claimed", expires)
+
+    def release(self, task_id: str, worker_id: str, next_status: str = "queued", now: datetime | None = None) -> bool:
+        if next_status in ACTIVE_LEASE_STATES:
+            raise ValueError("release next_status cannot retain an active lease state")
+        now_s = _iso(now or _utcnow())
+        with self.conn:
+            row = self.conn.execute("SELECT claimed_by FROM tasks WHERE task_id=?", (task_id,)).fetchone()
+            if not row or row["claimed_by"] != worker_id:
+                return False
+            self.conn.execute(
+                "UPDATE tasks SET status=?, claimed_by=NULL, lease_expires_at=NULL, updated_at=? WHERE task_id=?",
+                (next_status, now_s, task_id),
+            )
+            self._event(task_id, "task_released", worker_id, {"status": next_status}, now_s)
+            return True
+
+    def reap_expired(self, now: datetime | None = None) -> list[str]:
+        now = now or _utcnow()
+        now_s = _iso(now)
+        rows = self.conn.execute(
+            "SELECT task_id, claimed_by, lease_expires_at FROM tasks WHERE claimed_by IS NOT NULL"
+        ).fetchall()
+        expired = [r for r in rows if (_parse(r["lease_expires_at"]) or now) <= now]
+        with self.conn:
+            for row in expired:
+                self.conn.execute(
+                    "UPDATE tasks SET status='queued', claimed_by=NULL, lease_expires_at=NULL, updated_at=? WHERE task_id=?",
+                    (now_s, row["task_id"]),
+                )
+                self._event(row["task_id"], "lease_expired", row["claimed_by"], {}, now_s)
+        return [r["task_id"] for r in expired]
+
+    def events(self, task_id: str) -> list[dict]:
+        rows = self.conn.execute(
+            "SELECT event_type,actor,detail_json,created_at FROM events WHERE task_id=? ORDER BY event_id",
+            (task_id,),
+        ).fetchall()
+        return [{"event_type": r["event_type"], "actor": r["actor"], "detail": json.loads(r["detail_json"]), "created_at": r["created_at"]} for r in rows]
+
+    def _event(self, task_id: str, event_type: str, actor: str | None, detail: Mapping, created_at: str) -> None:
+        self.conn.execute(
+            "INSERT INTO events(task_id,event_type,actor,detail_json,created_at) VALUES(?,?,?,?,?)",
+            (task_id, event_type, actor, json.dumps(dict(detail), sort_keys=True), created_at),
+        )

--- a/elysia_collective_seed/autopilot/task_packet_schema.json
+++ b/elysia_collective_seed/autopilot/task_packet_schema.json
@@ -10,6 +10,7 @@
     "status": {"enum": ["queued", "claimed", "running", "review", "blocked", "completed", "rejected", "archived"]},
     "task_class": {"enum": ["research", "archaeology", "analysis", "design", "implementation", "test", "review", "documentation", "integration", "migration", "security", "governance", "other"]},
     "risk_class": {"enum": ["read_only", "sandbox_write", "repo_write", "external_write", "deployment", "sensitive_data", "privileged"]},
+    "required_capabilities": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true, "default": []},
     "preferred_worker": {"type": ["string", "null"]},
     "allowed_workers": {"type": "array", "items": {"type": "string"}, "default": []},
     "dependencies": {"type": "array", "items": {"type": "string"}, "default": []},

--- a/elysia_collective_seed/autopilot/task_packet_schema.json
+++ b/elysia_collective_seed/autopilot/task_packet_schema.json
@@ -7,7 +7,7 @@
     "task_id": {"type": "string", "pattern": "^ELY-TASK-[0-9]{6,}$"},
     "title": {"type": "string", "minLength": 1},
     "objective": {"type": "string", "minLength": 1},
-    "status": {"enum": ["queued", "claimed", "running", "review", "blocked", "completed", "rejected", "archived"]},
+    "status": {"enum": ["queued", "claimed", "running", "verifying", "review", "blocked", "human_review", "completed", "rejected", "archived"]},
     "task_class": {"enum": ["research", "archaeology", "analysis", "design", "implementation", "test", "review", "documentation", "integration", "migration", "security", "governance", "other"]},
     "risk_class": {"enum": ["read_only", "sandbox_write", "repo_write", "external_write", "deployment", "sensitive_data", "privileged"]},
     "required_capabilities": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true, "default": []},

--- a/elysia_collective_seed/autopilot/test_completion_validator.py
+++ b/elysia_collective_seed/autopilot/test_completion_validator.py
@@ -1,4 +1,4 @@
-from .completion_validator import validate_completion
+from elysia_collective_seed.autopilot.completion_validator import validate_completion
 
 
 def packet(**overrides):

--- a/elysia_collective_seed/autopilot/test_completion_validator.py
+++ b/elysia_collective_seed/autopilot/test_completion_validator.py
@@ -1,0 +1,63 @@
+from .completion_validator import validate_completion
+
+
+def packet(**overrides):
+    value = {
+        "task_id": "ELY-TASK-42",
+        "worker": {"provider": "dryrun", "role": "engineer"},
+        "outcome": "completed",
+        "summary": "bounded work completed",
+        "checks": [{"name": "unit", "result": "pass"}],
+        "next_recommendation": {"action": "verify"},
+    }
+    value.update(overrides)
+    return value
+
+
+def test_valid_completion_with_required_check():
+    result = validate_completion(packet(), expected_task_id="ELY-TASK-42", required_checks=("unit",))
+    assert result.valid
+    assert result.reasons == ()
+
+
+def test_rejects_task_identity_mismatch():
+    result = validate_completion(packet(), expected_task_id="ELY-TASK-99")
+    assert not result.valid
+    assert "task_id_mismatch" in result.reasons
+
+
+def test_rejects_missing_required_check():
+    result = validate_completion(packet(), required_checks=("unit", "safety"))
+    assert not result.valid
+    assert "missing_required_check:safety" in result.reasons
+
+
+def test_rejects_nonpassing_required_check():
+    result = validate_completion(
+        packet(checks=[{"name": "unit", "result": "skip"}]),
+        required_checks=("unit",),
+    )
+    assert not result.valid
+    assert "required_check_not_passed:unit:skip" in result.reasons
+
+
+def test_completed_cannot_contain_failed_check():
+    result = validate_completion(packet(checks=[{"name": "unit", "result": "fail"}]))
+    assert not result.valid
+    assert "completed_with_failed_check" in result.reasons
+
+
+def test_rejects_duplicate_check_names():
+    result = validate_completion(packet(checks=[
+        {"name": "unit", "result": "pass"},
+        {"name": "unit", "result": "pass"},
+    ]))
+    assert not result.valid
+    assert "duplicate_check:unit" in result.reasons
+
+
+def test_partial_outcome_may_report_failed_check():
+    result = validate_completion(
+        packet(outcome="partial", checks=[{"name": "unit", "result": "fail"}])
+    )
+    assert result.valid

--- a/elysia_collective_seed/autopilot/test_dispatcher.py
+++ b/elysia_collective_seed/autopilot/test_dispatcher.py
@@ -1,0 +1,73 @@
+from elysia_collective_seed.autopilot.dispatcher import Worker, dispatch, validate_followup
+
+
+def workers():
+    return [
+        Worker("codex", "openai", frozenset({"implementation", "test"}), frozenset({"sandbox_write", "repo_write"}), quality=.9, cost=.6),
+        Worker("cursor-local", "cursor", frozenset({"archaeology", "analysis"}), frozenset({"read_only", "sandbox_write"}), quality=.8, cost=.4),
+    ]
+
+
+def task(**overrides):
+    base = {
+        "task_id": "ELY-TASK-000001",
+        "title": "Implement bounded adapter",
+        "status": "queued",
+        "task_class": "implementation",
+        "risk_class": "repo_write",
+        "dependencies": [],
+        "acceptance_criteria": ["tests pass"],
+        "source_refs": ["github:#8"],
+        "attempt": 0,
+        "max_attempts": 3,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_routes_to_capable_worker():
+    d = dispatch(task(), {}, workers())
+    assert d.state == "dispatch"
+    assert d.worker_id == "codex"
+
+
+def test_blocks_incomplete_dependency():
+    d = dispatch(task(dependencies=["ELY-TASK-000000"]), {"ELY-TASK-000000": "running"}, workers())
+    assert d.state == "blocked"
+    assert "dependencies_incomplete" in d.reasons
+
+
+def test_protected_risk_requires_gate():
+    d = dispatch(task(risk_class="deployment"), {}, workers())
+    assert d.state == "human_gate"
+
+
+def test_attempt_limit_blocks_retry():
+    d = dispatch(task(attempt=3, max_attempts=3), {}, workers())
+    assert d.state == "blocked"
+    assert "attempt_limit_reached" in d.reasons
+
+
+def test_followup_cannot_expand_source_scope():
+    parent = task()
+    proposal = task(task_id="ELY-TASK-000002", title="Follow up", risk_class="sandbox_write", source_refs=["github:#8", "private:new"])
+    ok, reasons = validate_followup(parent, proposal, [])
+    assert not ok
+    assert "source_scope_expansion" in reasons
+
+
+def test_followup_deduplicates_title():
+    parent = task()
+    proposal = task(task_id="ELY-TASK-000002", title="Follow up", risk_class="sandbox_write")
+    open_tasks = [{"title": " follow UP "}]
+    ok, reasons = validate_followup(parent, proposal, open_tasks)
+    assert not ok
+    assert "duplicate_open_task" in reasons
+
+
+def test_bounded_followup_is_accepted():
+    parent = task()
+    proposal = task(task_id="ELY-TASK-000002", title="Add more tests", risk_class="sandbox_write")
+    ok, reasons = validate_followup(parent, proposal, [])
+    assert ok
+    assert reasons == ()

--- a/elysia_collective_seed/autopilot/test_dryrun_orchestrator.py
+++ b/elysia_collective_seed/autopilot/test_dryrun_orchestrator.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+from elysia_collective_seed.autopilot.dispatcher import Worker
+from elysia_collective_seed.autopilot.dryrun_orchestrator import dispatch_and_claim
+from elysia_collective_seed.autopilot.task_ledger import TaskLedger
+
+
+def _task(task_id="ELY-TASK-DRY-001", **overrides):
+    task = {
+        "task_id": task_id,
+        "title": "Dry-run task",
+        "objective": "Verify deterministic orchestration",
+        "task_class": "code",
+        "risk_class": "sandbox_write",
+        "status": "queued",
+        "dependencies": [],
+        "required_capabilities": [],
+        "allowed_workers": ["worker-a"],
+        "acceptance_criteria": ["claimed exactly once"],
+        "source_refs": ["github:#8"],
+        "attempt": 0,
+        "max_attempts": 3,
+        "human_approval_required": False,
+    }
+    task.update(overrides)
+    return task
+
+
+def _workers():
+    return [
+        Worker(
+            worker_id="worker-a",
+            provider="dryrun",
+            capabilities=frozenset({"code"}),
+            risk_classes=frozenset({"read_only", "sandbox_write", "repo_write"}),
+        )
+    ]
+
+
+def test_dispatch_and_claim_happy_path(tmp_path: Path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    try:
+        result = dispatch_and_claim(ledger, _task(), {}, _workers(), lease_seconds=60)
+        assert result.state == "claimed"
+        assert result.worker_id == "worker-a"
+        assert result.claim is not None and result.claim.claimed
+        persisted = ledger.get("ELY-TASK-DRY-001")
+        assert persisted["status"] == "claimed"
+        assert persisted["claimed_by"] == "worker-a"
+        assert persisted["attempt"] == 1
+    finally:
+        ledger.close()
+
+
+def test_human_gate_never_claims(tmp_path: Path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    try:
+        result = dispatch_and_claim(
+            ledger,
+            _task(human_approval_required=True),
+            {},
+            _workers(),
+        )
+        assert result.state == "human_gate"
+        assert result.claim is None
+        assert ledger.get("ELY-TASK-DRY-001")["claimed_by"] is None
+    finally:
+        ledger.close()
+
+
+def test_incomplete_dependency_never_claims(tmp_path: Path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    try:
+        result = dispatch_and_claim(
+            ledger,
+            _task(dependencies=["ELY-DEP-1"]),
+            {"ELY-DEP-1": "queued"},
+            _workers(),
+        )
+        assert result.state == "blocked"
+        assert result.reasons == ("dependencies_incomplete",)
+        assert ledger.get("ELY-TASK-DRY-001")["claimed_by"] is None
+    finally:
+        ledger.close()
+
+
+def test_existing_active_lease_is_not_stolen(tmp_path: Path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    try:
+        task = _task()
+        ledger.put_task(task)
+        first = ledger.claim(task["task_id"], "other-worker", lease_seconds=60)
+        assert first.claimed
+        result = dispatch_and_claim(ledger, task, {}, _workers(), lease_seconds=60)
+        assert result.state == "claim_blocked"
+        assert result.claim is not None and result.claim.reason == "active_lease"
+        persisted = ledger.get(task["task_id"])
+        assert persisted["claimed_by"] == "other-worker"
+        assert persisted["attempt"] == 1
+    finally:
+        ledger.close()
+
+
+def test_stale_payload_cannot_reopen_completed_task(tmp_path: Path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    try:
+        task = _task()
+        ledger.put_task(task)
+        assert ledger.claim(task["task_id"], "worker-a", lease_seconds=60).claimed
+        assert ledger.release(task["task_id"], "worker-a", next_status="completed")
+        result = dispatch_and_claim(ledger, task, {}, _workers())
+        assert result.state == "not_dispatchable"
+        assert result.reasons == ("terminal_task",)
+        persisted = ledger.get(task["task_id"])
+        assert persisted["status"] == "completed"
+        assert persisted["claimed_by"] is None
+    finally:
+        ledger.close()

--- a/elysia_collective_seed/autopilot/test_dryrun_orchestrator.py
+++ b/elysia_collective_seed/autopilot/test_dryrun_orchestrator.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from elysia_collective_seed.autopilot.dispatcher import Worker
-from elysia_collective_seed.autopilot.dryrun_orchestrator import dispatch_and_claim
+from elysia_collective_seed.autopilot.dryrun_orchestrator import dispatch_and_claim, validate_and_apply_completion
 from elysia_collective_seed.autopilot.task_ledger import TaskLedger
 
 
@@ -27,14 +27,20 @@ def _task(task_id="ELY-TASK-DRY-001", **overrides):
 
 
 def _workers():
-    return [
-        Worker(
-            worker_id="worker-a",
-            provider="dryrun",
-            capabilities=frozenset({"code"}),
-            risk_classes=frozenset({"read_only", "sandbox_write", "repo_write"}),
-        )
-    ]
+    return [Worker(worker_id="worker-a", provider="dryrun", capabilities=frozenset({"code"}), risk_classes=frozenset({"read_only", "sandbox_write", "repo_write"}))]
+
+
+def _completion(outcome="completed", **overrides):
+    packet = {
+        "task_id": "ELY-TASK-DRY-001",
+        "worker": {"provider": "dryrun", "role": "engineer"},
+        "outcome": outcome,
+        "summary": "bounded dry-run result",
+        "checks": [{"name": "unit", "result": "pass"}],
+        "next_recommendation": {"action": "verify" if outcome == "completed" else "continue"},
+    }
+    packet.update(overrides)
+    return packet
 
 
 def test_dispatch_and_claim_happy_path(tmp_path: Path):
@@ -55,12 +61,7 @@ def test_dispatch_and_claim_happy_path(tmp_path: Path):
 def test_human_gate_never_claims(tmp_path: Path):
     ledger = TaskLedger(tmp_path / "ledger.db")
     try:
-        result = dispatch_and_claim(
-            ledger,
-            _task(human_approval_required=True),
-            {},
-            _workers(),
-        )
+        result = dispatch_and_claim(ledger, _task(human_approval_required=True), {}, _workers())
         assert result.state == "human_gate"
         assert result.claim is None
         assert ledger.get("ELY-TASK-DRY-001")["claimed_by"] is None
@@ -71,12 +72,7 @@ def test_human_gate_never_claims(tmp_path: Path):
 def test_incomplete_dependency_never_claims(tmp_path: Path):
     ledger = TaskLedger(tmp_path / "ledger.db")
     try:
-        result = dispatch_and_claim(
-            ledger,
-            _task(dependencies=["ELY-DEP-1"]),
-            {"ELY-DEP-1": "queued"},
-            _workers(),
-        )
+        result = dispatch_and_claim(ledger, _task(dependencies=["ELY-DEP-1"]), {"ELY-DEP-1": "queued"}, _workers())
         assert result.state == "blocked"
         assert result.reasons == ("dependencies_incomplete",)
         assert ledger.get("ELY-TASK-DRY-001")["claimed_by"] is None
@@ -116,3 +112,52 @@ def test_stale_payload_cannot_reopen_completed_task(tmp_path: Path):
         assert persisted["claimed_by"] is None
     finally:
         ledger.close()
+
+
+def test_completed_worker_report_moves_to_verifying_not_completed(tmp_path: Path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    try:
+        dispatch_and_claim(ledger, _task(), {}, _workers(), lease_seconds=60)
+        result = validate_and_apply_completion(ledger, _completion(), worker_id="worker-a", required_checks=("unit",))
+        assert result.applied and result.state == "verifying"
+        persisted = ledger.get("ELY-TASK-DRY-001")
+        assert persisted["status"] == "verifying"
+        assert persisted["claimed_by"] is None
+    finally:
+        ledger.close()
+
+
+def test_completion_from_non_owner_cannot_mutate_task(tmp_path: Path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    try:
+        dispatch_and_claim(ledger, _task(), {}, _workers(), lease_seconds=60)
+        result = validate_and_apply_completion(ledger, _completion(), worker_id="worker-b")
+        assert not result.applied
+        assert result.reasons == ("lease_owner_mismatch",)
+        assert ledger.get("ELY-TASK-DRY-001")["status"] == "claimed"
+    finally:
+        ledger.close()
+
+
+def test_invalid_completion_cannot_mutate_task(tmp_path: Path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    try:
+        dispatch_and_claim(ledger, _task(), {}, _workers(), lease_seconds=60)
+        result = validate_and_apply_completion(ledger, _completion(checks=[{"name": "unit", "result": "fail"}]), worker_id="worker-a")
+        assert not result.applied
+        assert "completed_with_failed_check" in result.reasons
+        assert ledger.get("ELY-TASK-DRY-001")["status"] == "claimed"
+    finally:
+        ledger.close()
+
+
+def test_partial_and_failed_work_return_to_queue(tmp_path: Path):
+    for outcome in ("partial", "failed"):
+        ledger = TaskLedger(tmp_path / f"{outcome}.db")
+        try:
+            dispatch_and_claim(ledger, _task(), {}, _workers(), lease_seconds=60)
+            result = validate_and_apply_completion(ledger, _completion(outcome=outcome), worker_id="worker-a")
+            assert result.applied and result.state == "queued"
+            assert ledger.get("ELY-TASK-DRY-001")["claimed_by"] is None
+        finally:
+            ledger.close()

--- a/elysia_collective_seed/autopilot/test_task_ledger.py
+++ b/elysia_collective_seed/autopilot/test_task_ledger.py
@@ -1,0 +1,74 @@
+from datetime import datetime, timedelta, timezone
+
+from elysia_collective_seed.autopilot.task_ledger import TaskLedger
+
+
+def _task(task_id="ELY-TASK-1", status="queued"):
+    return {"task_id": task_id, "title": "bounded test", "status": status, "attempt": 0}
+
+
+def test_claim_prevents_second_worker(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    now = datetime(2026, 9, 7, tzinfo=timezone.utc)
+    ledger.put_task(_task())
+    first = ledger.claim("ELY-TASK-1", "worker-a", 60, now)
+    second = ledger.claim("ELY-TASK-1", "worker-b", 60, now + timedelta(seconds=1))
+    assert first.claimed is True
+    assert second.claimed is False
+    assert second.reason == "active_lease"
+    assert ledger.get("ELY-TASK-1")["attempt"] == 1
+    ledger.close()
+
+
+def test_same_worker_renews_without_incrementing_attempt(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    now = datetime(2026, 9, 7, tzinfo=timezone.utc)
+    ledger.put_task(_task())
+    ledger.claim("ELY-TASK-1", "worker-a", 60, now)
+    renewed = ledger.claim("ELY-TASK-1", "worker-a", 120, now + timedelta(seconds=10))
+    assert renewed.reason == "renewed"
+    assert ledger.get("ELY-TASK-1")["attempt"] == 1
+    ledger.close()
+
+
+def test_expired_lease_can_be_reaped_and_reclaimed(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    now = datetime(2026, 9, 7, tzinfo=timezone.utc)
+    ledger.put_task(_task())
+    ledger.claim("ELY-TASK-1", "worker-a", 10, now)
+    assert ledger.reap_expired(now + timedelta(seconds=11)) == ["ELY-TASK-1"]
+    claimed = ledger.claim("ELY-TASK-1", "worker-b", 60, now + timedelta(seconds=12))
+    assert claimed.claimed is True
+    assert ledger.get("ELY-TASK-1")["attempt"] == 2
+    ledger.close()
+
+
+def test_release_requires_current_owner(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    now = datetime(2026, 9, 7, tzinfo=timezone.utc)
+    ledger.put_task(_task())
+    ledger.claim("ELY-TASK-1", "worker-a", 60, now)
+    assert ledger.release("ELY-TASK-1", "worker-b", now=now) is False
+    assert ledger.release("ELY-TASK-1", "worker-a", "queued", now) is True
+    assert ledger.get("ELY-TASK-1")["claimed_by"] is None
+    ledger.close()
+
+
+def test_terminal_task_cannot_be_claimed(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    ledger.put_task(_task(status="completed"))
+    result = ledger.claim("ELY-TASK-1", "worker-a")
+    assert result.claimed is False
+    assert result.reason == "terminal_task"
+    ledger.close()
+
+
+def test_events_are_auditable(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    now = datetime(2026, 9, 7, tzinfo=timezone.utc)
+    ledger.put_task(_task())
+    ledger.claim("ELY-TASK-1", "worker-a", 60, now)
+    ledger.release("ELY-TASK-1", "worker-a", now=now)
+    event_types = [event["event_type"] for event in ledger.events("ELY-TASK-1")]
+    assert event_types == ["task_upserted", "task_claimed", "task_released"]
+    ledger.close()

--- a/elysia_collective_seed/autopilot/test_task_ledger.py
+++ b/elysia_collective_seed/autopilot/test_task_ledger.py
@@ -20,6 +20,23 @@ def test_claim_prevents_second_worker(tmp_path):
     ledger.close()
 
 
+def test_independent_connections_observe_single_lease_owner(tmp_path):
+    path = tmp_path / "ledger.db"
+    first_ledger = TaskLedger(path)
+    second_ledger = TaskLedger(path)
+    now = datetime(2026, 9, 7, tzinfo=timezone.utc)
+    first_ledger.put_task(_task())
+    first = first_ledger.claim("ELY-TASK-1", "worker-a", 60, now)
+    second = second_ledger.claim("ELY-TASK-1", "worker-b", 60, now)
+    assert first.claimed is True
+    assert second.claimed is False
+    assert second.reason == "active_lease"
+    assert second_ledger.get("ELY-TASK-1")["claimed_by"] == "worker-a"
+    assert second_ledger.get("ELY-TASK-1")["attempt"] == 1
+    first_ledger.close()
+    second_ledger.close()
+
+
 def test_same_worker_renews_without_incrementing_attempt(tmp_path):
     ledger = TaskLedger(tmp_path / "ledger.db")
     now = datetime(2026, 9, 7, tzinfo=timezone.utc)
@@ -28,6 +45,17 @@ def test_same_worker_renews_without_incrementing_attempt(tmp_path):
     renewed = ledger.claim("ELY-TASK-1", "worker-a", 120, now + timedelta(seconds=10))
     assert renewed.reason == "renewed"
     assert ledger.get("ELY-TASK-1")["attempt"] == 1
+    ledger.close()
+
+
+def test_same_worker_reacquires_expired_lease_as_new_attempt(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    now = datetime(2026, 9, 7, tzinfo=timezone.utc)
+    ledger.put_task(_task())
+    ledger.claim("ELY-TASK-1", "worker-a", 10, now)
+    reacquired = ledger.claim("ELY-TASK-1", "worker-a", 60, now + timedelta(seconds=11))
+    assert reacquired.reason == "claimed"
+    assert ledger.get("ELY-TASK-1")["attempt"] == 2
     ledger.close()
 
 
@@ -60,6 +88,15 @@ def test_terminal_task_cannot_be_claimed(tmp_path):
     result = ledger.claim("ELY-TASK-1", "worker-a")
     assert result.claimed is False
     assert result.reason == "terminal_task"
+    ledger.close()
+
+
+def test_stale_upsert_cannot_reopen_terminal_task(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.db")
+    ledger.put_task(_task(status="completed"))
+    ledger.put_task(_task(status="queued"))
+    assert ledger.get("ELY-TASK-1")["status"] == "completed"
+    assert ledger.claim("ELY-TASK-1", "worker-a").reason == "terminal_task"
     ledger.close()
 
 

--- a/elysia_collective_seed/autopilot/test_task_schema_alignment.py
+++ b/elysia_collective_seed/autopilot/test_task_schema_alignment.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+
+SCHEMA = Path(__file__).with_name("task_packet_schema.json")
+
+
+def test_task_schema_declares_dispatcher_capability_field():
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    assert schema["additionalProperties"] is False
+    assert "required_capabilities" in schema["properties"]
+    prop = schema["properties"]["required_capabilities"]
+    assert prop["type"] == "array"
+    assert prop["uniqueItems"] is True
+
+
+def test_dispatcher_fields_are_schema_declared():
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    declared = set(schema["properties"])
+    dispatcher_fields = {
+        "task_id",
+        "status",
+        "risk_class",
+        "required_capabilities",
+        "task_class",
+        "allowed_workers",
+        "dependencies",
+        "human_approval_required",
+        "attempt",
+        "max_attempts",
+        "preferred_worker",
+        "acceptance_criteria",
+        "source_refs",
+        "title",
+    }
+    assert dispatcher_fields <= declared

--- a/elysia_collective_seed/autopilot/test_task_schema_alignment.py
+++ b/elysia_collective_seed/autopilot/test_task_schema_alignment.py
@@ -34,3 +34,9 @@ def test_dispatcher_fields_are_schema_declared():
         "title",
     }
     assert dispatcher_fields <= declared
+
+
+def test_task_schema_declares_runtime_control_states():
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    states = set(schema["properties"]["status"]["enum"])
+    assert {"queued", "claimed", "running", "verifying", "review", "blocked", "human_review", "completed", "rejected", "archived"} <= states

--- a/elysia_collective_seed/autopilot/test_task_state_machine.py
+++ b/elysia_collective_seed/autopilot/test_task_state_machine.py
@@ -1,0 +1,54 @@
+"""Pytest-discoverable coverage for the pure AUTOPILOT task-state policy."""
+from elysia_collective_seed.autopilot.task_state_machine import can_claim, validate_transition
+
+
+def test_claim_requires_dependencies():
+    assert can_claim(status="queued", dependencies_satisfied=True, attempts=0, max_attempts=3).allowed
+    assert not can_claim(status="queued", dependencies_satisfied=False, attempts=0, max_attempts=3).allowed
+
+
+def test_attempt_budget_is_enforced():
+    result = can_claim(status="queued", dependencies_satisfied=True, attempts=3, max_attempts=3)
+    assert not result.allowed
+    assert result.reason == "attempt_budget_exhausted"
+
+
+def test_runtime_completion_requires_verification():
+    result = validate_transition("review", "completed", risk_class="repo_write", runtime_behavior_changed=True)
+    assert not result.allowed
+    assert result.reason == "independent_verification_missing"
+
+
+def test_verified_runtime_completion_is_allowed():
+    result = validate_transition(
+        "review", "completed", risk_class="repo_write",
+        runtime_behavior_changed=True, independent_verification_passed=True,
+    )
+    assert result.allowed
+
+
+def test_high_authority_completion_requires_approval():
+    result = validate_transition(
+        "review", "completed", risk_class="deployment",
+        independent_verification_passed=True,
+    )
+    assert not result.allowed
+    assert result.reason == "human_approval_missing"
+
+
+def test_shortcut_from_queue_to_complete_is_rejected():
+    result = validate_transition("queued", "completed", risk_class="read_only")
+    assert not result.allowed
+    assert result.reason == "transition_not_allowed"
+
+
+def test_unknown_state_is_rejected():
+    result = validate_transition("mystery", "completed", risk_class="read_only")
+    assert not result.allowed
+    assert result.reason == "unknown_current_state"
+
+
+def test_archived_is_terminal():
+    result = validate_transition("archived", "queued", risk_class="read_only")
+    assert not result.allowed
+    assert result.reason == "transition_not_allowed"


### PR DESCRIPTION
Implements the current bounded AUTOPILOT-004 dispatcher/orchestration foundation on an isolated branch.

## Included
- deterministic provider-neutral worker registry and routing gates
- dependency, risk/human-authority, attempt-limit, capability, and allowed-worker checks
- persistent task ledger and auditable transitions
- execution claim/lease ownership boundaries
- completion-packet validation and ledger application
- successful producer completion routes to independent verification rather than self-completing
- queued-only acquisition prevents review/blocked work from silently re-entering execution
- autonomous follow-up validation preventing source-scope expansion and duplicate task creation
- schema-alignment and state-machine regression coverage
- implementation/repair handoff evidence

## Executable verification
Current head: `9704b638d4b2514163f226c9c0bcb1b9b9bf9268`.

GitHub Actions `Elysia Autopilot CI` run `34155380246` completed successfully (`conclusion: success`, run 104). This clears the prior seed-test/runtime-disable verification blocker for the current head.

## Explicitly not enabled
- provider/model invocation
- Guardian runtime wiring
- network/subprocess execution by workers
- merge/deployment
- external posting
- credential/private-chatlog access
- Cursor/Codex live adapters

## Handoff / remaining gate
Keep this PR draft and unmerged. It targets `elysia-collective-0.1-seed`, not `main`. The next bounded AUTOPILOT-004 work should focus on the remaining disabled synchronization/adapter surfaces and end-to-end synthetic graph acceptance evidence without activating providers or Guardian runtime behavior. Final integration remains gated on local Guardian/archive reconciliation and AUTOPILOT-003.

Refs #8.