### PR TITLE
AUTOPILOT-004 align task schema control states [DRAFT]

### DIFF
--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000014-schema-state-alignment.md
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000014-schema-state-alignment.md
@@ -1,0 +1,22 @@
+# ELY-TASK-000014 — Task schema/runtime state alignment
+
+## Objective
+Keep the provider-neutral task packet contract aligned with the runtime ledger state machine without enabling runtime providers or Guardian execution.
+
+## Finding
+The AUTOPILOT-004 ledger treats `verifying` and `human_review` as explicit non-dispatchable control states, but the task packet JSON Schema did not permit those values. That allowed runtime state to diverge from the durable interchange contract.
+
+## Changes
+- Added `verifying` and `human_review` to `task_packet_schema.json` status enum.
+- Added a regression assertion that all current runtime control states are declared by the schema.
+
+## Safety
+Schema/test-only change on isolated branch `autopilot-004-schema-state-alignment`. No provider invocation, Guardian runtime wiring, network/subprocess execution, deployment, external posting, credential access, or merge.
+
+## Evidence
+- Source ledger: `elysia_collective_seed/autopilot/task_ledger.py` defines `verifying` and `human_review` as non-dispatchable states.
+- Contract: `elysia_collective_seed/autopilot/task_packet_schema.json` now admits both states.
+- Regression: `elysia_collective_seed/autopilot/test_task_schema_alignment.py::test_task_schema_declares_runtime_control_states`.
+
+## Handoff
+Independent verification should run the existing AUTOPILOT CI/test suite on this branch. If green, this bounded repair can be incorporated into the AUTOPILOT-004 draft branch without changing its draft/unmerged integration gate.

--- a/elysia_collective_seed/autopilot/task_packet_schema.json
+++ b/elysia_collective_seed/autopilot/task_packet_schema.json
@@ -7,7 +7,7 @@
     "task_id": {"type": "string", "pattern": "^ELY-TASK-[0-9]{6,}$"},
     "title": {"type": "string", "minLength": 1},
     "objective": {"type": "string", "minLength": 1},
-    "status": {"enum": ["queued", "claimed", "running", "review", "blocked", "completed", "rejected", "archived"]},
+    "status": {"enum": ["queued", "claimed", "running", "verifying", "review", "blocked", "human_review", "completed", "rejected", "archived"]},
     "task_class": {"enum": ["research", "archaeology", "analysis", "design", "implementation", "test", "review", "documentation", "integration", "migration", "security", "governance", "other"]},
     "risk_class": {"enum": ["read_only", "sandbox_write", "repo_write", "external_write", "deployment", "sensitive_data", "privileged"]},
     "required_capabilities": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true, "default": []},

--- a/elysia_collective_seed/autopilot/test_task_schema_alignment.py
+++ b/elysia_collective_seed/autopilot/test_task_schema_alignment.py
@@ -34,3 +34,9 @@ def test_dispatcher_fields_are_schema_declared():
         "title",
     }
     assert dispatcher_fields <= declared
+
+
+def test_task_schema_declares_runtime_control_states():
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    states = set(schema["properties"]["status"]["enum"])
+    assert {"queued", "claimed", "running", "verifying", "review", "blocked", "human_review", "completed", "rejected", "archived"} <= states


### PR DESCRIPTION
Bounded schema-alignment verification PR for ELY-TASK-000014.

## Scope
- Align `task_packet_schema.json` with the runtime's existing non-dispatchable `verifying` and `human_review` control states.
- Add regression coverage for the runtime control-state set.
- Preserve durable handoff evidence.

## Safety
This changes no provider invocation, Guardian runtime wiring, network/subprocess execution, deployment, external posting, credentials/private-chatlog access, or authority boundaries.

## Verification gate
This PR exists to obtain independent CI/test evidence before any incorporation into the AUTOPILOT-004 dispatcher draft. Keep draft and unmerged.

Refs #8.