### PR TITLE
AUTOPILOT-004: verifier lifecycle contract

### DIFF
--- a/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000016-verifier-lifecycle-contract.md
+++ b/elysia_collective_seed/autopilot/handoffs/ELY-TASK-000016-verifier-lifecycle-contract.md
@@ -1,0 +1,23 @@
+# ELY-TASK-000016 handoff
+
+Task: Define the independent verifier lifecycle required by AUTOPILOT-004 acceptance evidence.
+Branch: `autopilot-004-verifier-lifecycle-contract`
+Base: `autopilot-004-dispatcher-foundation`
+
+## Completed
+
+Added `verifier_lifecycle_contract.md`, defining producer-to-verifier state boundaries, writer/verifier separation, verifier eligibility/lease semantics, accept/reject behavior, retry/human-review routing, audit preservation, and ten required executable tests.
+
+## Evidence
+
+Contract commit: `74690adf5892e46b59defb3c7d1e33dd73123117`.
+
+The contract was derived from the AUTOPILOT-004 acceptance-gap audit and the existing ledger behavior where producer completion stops at `verifying`. It is specification-only and does not alter runtime behavior.
+
+## Safety
+
+No provider calls, GitHub synchronization writer, Guardian runtime integration, network/subprocess execution, merge, deployment, external posting, credential access, private-chatlog access, or authority expansion was enabled.
+
+## Next bounded task
+
+Implement the contract on a fresh isolated child branch using deterministic local SQLite state only. Add executable tests for writer self-verification refusal, independent verifier claim, accept/reject paths, stale/wrong-worker refusal, verifier lease expiry/reclaim, retry/human-review routing, and audit reconstruction. Then obtain independent CI/review before incorporating any implementation into Draft PR #12.

--- a/elysia_collective_seed/autopilot/verifier_lifecycle_contract.md
+++ b/elysia_collective_seed/autopilot/verifier_lifecycle_contract.md
@@ -1,0 +1,92 @@
+# Independent verifier lifecycle contract
+
+Status: specification-only, runtime-disabled
+Scope: AUTOPILOT-004
+
+## Purpose
+
+Define the minimum deterministic ledger behavior required to route consequential write work from producer completion through an independent verifier without allowing the producer to self-approve or silently broaden authority.
+
+## Preconditions
+
+- The producer has an active execution lease for the task.
+- The submitted completion packet passes the repository completion-packet validator.
+- The task's risk/authority class has not increased relative to its approved task packet.
+- Any required human approval remains authoritative and cannot be replaced by verifier approval.
+
+## Producer submission
+
+For a write task, accepted producer submission MUST:
+
+1. append an auditable `producer_completion_submitted` event containing packet/evidence identifiers, never secrets or private chat content;
+2. release the producer execution lease;
+3. transition the task to `verifying`;
+4. persist the producer worker ID as `produced_by` (or equivalent immutable verification metadata);
+5. prevent normal execution dispatch while verification is pending.
+
+Producer submission MUST NOT transition a consequential write task directly to `completed`, `integrated`, deployed, merged, or any equivalent terminal/integration state.
+
+## Verifier eligibility and claim
+
+A verifier claim is eligible only when:
+
+- task status is `verifying`;
+- verifier worker ID differs from `produced_by`;
+- verifier capability satisfies the task's verification capability/risk requirements;
+- the worker is available under the worker registry;
+- no unexpired verifier lease exists;
+- any human/governance gate remains satisfied independently.
+
+The producer MUST be rejected with reason `self_verification_forbidden` if it attempts to claim verification of its own consequential write.
+
+Verifier claims SHOULD use a separate verification lease or equivalent claim record so execution leases cannot be confused with review authority.
+
+## Verifier acceptance
+
+A verifier acceptance MUST:
+
+1. require an active verifier claim owned by the accepting worker;
+2. record evidence references and an auditable `verification_accepted` event;
+3. release the verifier claim/lease;
+4. advance only to the task's pre-authorized post-verification state;
+5. preserve human/governance gates and never imply merge, deployment, external posting, secret access, or broader authority.
+
+For the current runtime-disabled seed, the safe post-verification state SHOULD be `completed` only for bounded local/specification/test work whose task packet already authorizes that terminal state. Integration into protected branches remains a separate gated action.
+
+## Verifier rejection
+
+A verifier rejection MUST:
+
+1. require an active verifier claim owned by the rejecting worker;
+2. append `verification_rejected` with bounded reason/evidence metadata;
+3. release the verifier claim/lease;
+4. return the task to `queued` when retry budget remains and no new human decision is required;
+5. transition to `blocked` or `human_review` when retry budget is exhausted, evidence is contradictory, or resolution would require authority expansion.
+
+Rejection MUST NOT discard the producer completion packet or prior evidence.
+
+## Retry and lease rules
+
+- Expired verifier leases may be reaped without altering producer evidence.
+- Reclaiming verification does not increment the producer execution attempt counter.
+- Repeated verification rejection must obey the task's bounded retry policy and cannot hot-loop indefinitely.
+- A verifier cannot mutate the task objective, risk class, private-data scope, deployment authority, or acceptance criteria.
+
+## Required executable tests
+
+The implementation is not acceptance-complete until tests prove:
+
+1. valid writer submission enters `verifying` and releases writer lease;
+2. writer cannot claim its own verification;
+3. a distinct eligible verifier can claim verification;
+4. verifier acceptance produces the authorized post-verification state and audit event;
+5. verifier rejection safely requeues when retry budget remains;
+6. rejection blocks/routes to human review when retry/authority policy requires it;
+7. stale or wrong-worker verifier decisions are refused;
+8. expired verifier lease can be reclaimed without losing completion evidence;
+9. no verification path proposes merge/deploy/external-post/private-data authority;
+10. the full transition history is reconstructable from persistent ledger state/events alone.
+
+## Safety boundary
+
+This contract authorizes no provider calls, GitHub writes, Guardian runtime wiring, subprocess/network execution, deployment, merge, external posting, credential access, or private-chatlog access. Implementation must remain deterministic/local-only until the canonical Guardian runtime and governance gates permit broader integration.


### PR DESCRIPTION
Draft verification lane for the independent-verifier lifecycle work identified by the AUTOPILOT-004 acceptance-gap audit.

Scope is intentionally bounded to runtime-disabled verifier lifecycle contract/tests/handoff. No provider invocation, Guardian runtime wiring, deployment, private-data expansion, or external posting authority.

Integration gate: CI must pass on the exact head and review must confirm write-task self-verification is rejected before this work is considered for incorporation into the dispatcher foundation.