### PR TITLE
AUTOPILOT-004: verifier lifecycle implementation

### DIFF
--- a/.github/workflows/elysia-autopilot-ci.yml
+++ b/.github/workflows/elysia-autopilot-ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - 'elysia-collective-*'
+      - 'autopilot-*'
   workflow_dispatch:
 
 permissions:
@@ -21,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -49,7 +52,13 @@ jobs:
           print('All JSON artifacts parsed successfully.')
 
       - name: Run Elysia Collective seed tests
-        run: python -m pytest -q elysia_collective_seed
+        run: >-
+          python -m pytest -q elysia_collective_seed
+          tests/test_autopilot_verifier.py
+          tests/test_autopilot_verifier_ledger_migration.py
+          tests/test_autopilot_verifier_lifecycle.py
+          tests/test_vega_verifier_boundaries.py
+          tests/test_autopilot_lifecycle_repairs.py
 
       - name: Enforce no runtime-enable flag in seed prompt pack
         shell: python

--- a/elysia_collective_seed/autopilot/completion_packet_schema.json
+++ b/elysia_collective_seed/autopilot/completion_packet_schema.json
@@ -5,6 +5,8 @@
   "required": ["task_id", "worker", "outcome", "summary", "checks", "next_recommendation"],
   "properties": {
     "task_id": {"type": "string"},
+    "packet_id": {"type": "string", "minLength": 1},
+    "evidence_refs": {"type": "array", "items": {"type": "string", "minLength": 1}},
     "worker": {
       "type": "object",
       "required": ["provider", "role"],

--- a/elysia_collective_seed/autopilot/completion_validator.py
+++ b/elysia_collective_seed/autopilot/completion_validator.py
@@ -41,6 +41,20 @@ def validate_completion(
     check names, required-check presence, and no failed required checks.
     """
     reasons: list[str] = []
+    if "packet_id" in packet and not _nonempty_string(packet["packet_id"]):
+        reasons.append("invalid_packet_id")
+    for field in ("evidence_refs", "commits", "pull_requests"):
+        if field in packet and (not isinstance(packet[field], list) or any(not _nonempty_string(ref) for ref in packet[field])):
+            reasons.append(f"invalid_{field}")
+    if "claims" in packet:
+        claims = packet["claims"]
+        if not isinstance(claims, list) or any(
+            not isinstance(claim, Mapping)
+            or not isinstance(claim.get("evidence"), list)
+            or any(not _nonempty_string(ref) for ref in claim["evidence"])
+            for claim in claims
+        ):
+            reasons.append("invalid_claim_evidence")
     task_id = packet.get("task_id")
     outcome = packet.get("outcome")
 

--- a/elysia_collective_seed/autopilot/dryrun_orchestrator.py
+++ b/elysia_collective_seed/autopilot/dryrun_orchestrator.py
@@ -8,6 +8,8 @@ and persists bounded local SQLite state transitions.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
+import json
 from typing import Mapping, Sequence
 
 from .completion_validator import CompletionValidation, validate_completion
@@ -101,6 +103,8 @@ def validate_and_apply_completion(
     or unrelated completion cannot mutate another worker's task.
     """
     task_id = str(packet.get("task_id", ""))
+    persisted = ledger.get(task_id)
+    required_checks = tuple(dict.fromkeys((*required_checks, *(persisted or {}).get("required_checks", []))))
     validation = validate_completion(
         packet,
         expected_task_id=task_id or None,
@@ -143,7 +147,23 @@ def validate_and_apply_completion(
         "failed": "queued",
         "rejected": "rejected",
     }[validation.outcome]
-    applied = ledger.release(validation.task_id, worker_id, next_status=next_state)
+    if validation.outcome == "completed":
+        # Schema-compatible older packets have no ID: bind them to a canonical
+        # digest instead of inventing a successful artifact or dropping evidence.
+        canonical = json.dumps(dict(packet), sort_keys=True, separators=(",", ":"), allow_nan=False)
+        digest = "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        packet_id = packet.get("packet_id", digest)
+        evidence = list(packet.get("evidence_refs", []))
+        evidence.extend(ref for claim in packet.get("claims", []) for ref in claim.get("evidence", []))
+        evidence.extend(packet.get("commits", []))
+        evidence.extend(packet.get("pull_requests", []))
+        evidence.append(digest)
+        applied = ledger.submit_for_verification(
+            validation.task_id, worker_id, packet_id, list(dict.fromkeys(evidence)),
+            completion_checks=[{"name": check["name"], "result": check["result"]} for check in packet["checks"]],
+        )
+    else:
+        applied = ledger.release(validation.task_id, worker_id, next_status=next_state)
     if not applied:
         return CompletionResult(
             task_id=validation.task_id,
@@ -155,7 +175,7 @@ def validate_and_apply_completion(
         )
     return CompletionResult(
         task_id=validation.task_id,
-        state=next_state,
+        state=ledger.get(validation.task_id)["status"],
         worker_id=worker_id,
         validation=validation,
         applied=True,

--- a/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-acceptance-gap-run-011.md
+++ b/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-acceptance-gap-run-011.md
@@ -1,0 +1,41 @@
+# AUTOPILOT-004 verifier lifecycle acceptance gap
+
+Status: supervisor verification checkpoint
+Scope: PR #15 / `autopilot-004-verifier-lifecycle-impl`
+
+## Evidence reviewed
+
+- `verifier_lifecycle_contract.md` from the reviewed contract branch.
+- `verifier.py` at PR #15 head before this handoff.
+- PR #15 metadata and exact head `611664b1a35d81947a66fa2aaf9f8a5f80cb959f`.
+
+## Implemented and bounded
+
+`select_verifier()` is deterministic and runtime-disabled. It rejects the producer, unavailable workers, unsupported risk/capability routes, missing verifier independence metadata, and same-independence-group workers. It selects only a distinct eligible verifier and grants no merge/deploy/external-write/private-data authority.
+
+## Acceptance gaps against the reviewed contract
+
+PR #15 is not acceptance-complete. The following contract requirements still need executable ledger behavior and tests:
+
+1. Producer submission must persist evidence identifiers, release the producer execution lease, record immutable `produced_by`, enter `verifying`, and prevent normal execution dispatch.
+2. Verification needs a distinct persistent lease/claim with owner and expiry; an unexpired verifier lease must block competing claims.
+3. Acceptance/rejection must require the active verifier-lease owner; stale and wrong-worker decisions must fail closed.
+4. Acceptance must append `verification_accepted`, release the verifier lease, and advance only to the pre-authorized post-verification state.
+5. Rejection must append `verification_rejected`, preserve producer packet/evidence, release the verifier lease, and either requeue within bounded retry policy or route to `blocked`/`human_review`.
+6. Expired verifier leases must be reclaimable without incrementing producer execution attempts or deleting producer evidence.
+7. Persistent state/events must be sufficient to reconstruct the full transition history.
+8. Tests must explicitly prove no verifier path grants or proposes merge, deploy, external-post, credential, or private-data authority.
+
+## Implementation constraint
+
+Implement these pieces by composing with the repository's existing deterministic local ledger/SQLite primitives where available rather than creating a second competing task ledger. Keep provider adapters and Guardian runtime wiring disabled. Do not change task objective, risk class, private-data scope, deployment authority, or acceptance criteria during verification.
+
+## Verification gate
+
+Do not mark PR #15 acceptance-complete or integrate it into the dispatcher lane until all ten executable tests named in `verifier_lifecycle_contract.md` pass on the exact PR head and an independent review confirms the authority boundary.
+
+## Handoff
+
+Next bounded step: extend the local persistent ledger with verifier-lease claim/expiry plus producer submission, accept, and reject transitions; then add the contract's ten executable tests. If existing ledger APIs conflict with this contract, preserve the contract and record the incompatibility rather than silently weakening either side.
+
+No merge, deployment, provider invocation, external posting, credential/private-chat access, destructive archive action, or authority expansion was performed in this checkpoint.

--- a/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-atomic-claim-run-020.md
+++ b/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-atomic-claim-run-020.md
@@ -32,6 +32,9 @@
 - CI-equivalent `python -m pytest -q elysia_collective_seed`: 43 passed.
 - Python compileall for changed implementation/test surfaces: passed.
 - `git diff --check`: passed (Git emitted only line-ending conversion warnings).
+- Implementation commit: `e6a2fa5df9fc51a5c991d7fd74e1c4bcb9e2ac34`.
+- Exact implementation-head GitHub Actions run: `34411704839`, Elysia
+  Autopilot CI run 144, `seed-validation` passed in 17 seconds.
 
 The local runner used pytest 8.3.5 directly from temporary wheel paths and an
 explicit worktree-local `--basetemp` because the host's default pytest temp

--- a/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-atomic-claim-run-020.md
+++ b/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-atomic-claim-run-020.md
@@ -1,0 +1,55 @@
+# AUTOPILOT-004 verifier atomic-claim handoff — run 020
+
+## Task
+
+- Issues: #16 (AUTOPILOT-004A), #17 (AUTOPILOT-004B)
+- PR lane: #15, `autopilot-004-verifier-lifecycle-impl`
+- Objective: close the exact-head CI failure and require independent-verifier
+  eligibility at the ledger claim transition.
+
+## Starting state
+
+- Starting SHA: `a64349434419214e26048ab6682b82a930a2558a`
+- Isolated implementation branch: `codex/guardian-004b-ci-fix`
+- Existing subsystem: `elysia_collective_seed/autopilot/task_ledger.py`
+- Initial CI-equivalent seed test result: 40 passed, 3 failed. All three
+  failures expected `active_lease` but received `state_not_claimable`.
+
+## Implementation
+
+- `VerificationDecision` now records the producer identity for which it was
+  issued.
+- `TaskLedger.claim_verification()` fails closed without an affirmative
+  decision, when the selected verifier differs, or when the decision belongs
+  to a different producer attempt.
+- Same-group and missing-group selector outcomes cannot acquire a ledger lease.
+- Active execution leases are classified as `active_lease` before the generic
+  non-claimable-state fallback, repairing the reproduced seed-suite failure.
+
+## Tests
+
+- Focused verifier, migration, and lifecycle suite: 13 passed.
+- CI-equivalent `python -m pytest -q elysia_collective_seed`: 43 passed.
+- Python compileall for changed implementation/test surfaces: passed.
+- `git diff --check`: passed (Git emitted only line-ending conversion warnings).
+
+The local runner used pytest 8.3.5 directly from temporary wheel paths and an
+explicit worktree-local `--basetemp` because the host's default pytest temp
+directory was inaccessible.
+
+## Evidence and risks
+
+- Direct ledger calls can no longer bypass a blocked/missing verifier decision.
+- A decision is bound to both the selected verifier and current producer.
+- This remains a local deterministic primitive. It does not invoke providers,
+  wire Guardian runtime, post externally, deploy, merge, or expand data access.
+- The decision object is not a cryptographic capability. Any future process or
+  network boundary must replace it with a persisted or signed authorization
+  artifact rather than trusting serialized caller input.
+
+## Verification request
+
+Independently verify the exact commit produced by this handoff, rerun the 13
+focused tests and 43 seed tests, and confirm that fabricated/missing/mismatched
+decisions cannot acquire a verifier lease. Keep PR #15 draft and unmerged until
+exact-head CI is green and the authority-boundary review passes.

--- a/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-impl-run-010.md
+++ b/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-impl-run-010.md
@@ -1,0 +1,23 @@
+# AUTOPILOT-004 verifier implementation handoff
+
+## Scope
+Implemented the first executable, runtime-disabled slice of the independent-verifier lifecycle on isolated branch `autopilot-004-verifier-lifecycle-impl`, based on the reviewed verifier contract branch.
+
+## Durable changes
+- Added `verifier.py` with deterministic verifier selection.
+- Producer worker is always excluded from verification.
+- Same-independence-group workers are excluded.
+- Missing independence metadata fails closed.
+- Verifier must possess the requested verification capability and risk allowance.
+- No provider invocation, external write, merge, deployment, or authority expansion is present.
+- Added four regression tests covering producer self-verification, same-group rejection, distinct-group acceptance, and missing-metadata fail-closed behavior.
+
+## Evidence
+Implementation commit: `58332f55eb1ec5d457ad924f6ee1df7bef739103`
+Test commit: `8e8e299cc16e0374f93517139b7ae8eed8107e29`
+
+## Verification gate
+This branch is not integrated. Next step is CI/test verification on the exact branch head, followed by independent review. If green, integrate only into the AUTOPILOT-004 dispatcher development lane, not `main` or the protected seed integration target.
+
+## Follow-up
+After this primitive is verified, wire verifier claims into the local SQLite ledger/state-transition implementation and add an end-to-end synthetic write -> review -> independent verification -> completed test. Keep all adapters runtime-disabled.

--- a/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-ledger-design-run-012.md
+++ b/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-ledger-design-run-012.md
@@ -1,0 +1,86 @@
+# AUTOPILOT-004 verifier ledger implementation design
+
+Status: supervisor implementation checkpoint
+Scope: PR #15 / `autopilot-004-verifier-lifecycle-impl`
+
+## Decision
+
+Extend the existing `TaskLedger`; do not create a second ledger. Keep execution lease fields (`claimed_by`, `lease_expires_at`) separate from verification claim fields so review authority cannot be confused with execution authority.
+
+## Minimal persistent schema extension
+
+Add nullable task columns:
+
+- `produced_by TEXT`
+- `completion_packet_id TEXT`
+- `completion_evidence_json TEXT`
+- `verification_claimed_by TEXT`
+- `verification_lease_expires_at TEXT`
+- `verification_rejections INTEGER NOT NULL DEFAULT 0`
+
+Evidence storage is identifiers/references only. No secrets, credentials, private chat text, or raw historical corpus belongs in these fields.
+
+## Bounded ledger API
+
+Implement these deterministic local-only operations:
+
+1. `submit_for_verification(task_id, producer_worker_id, packet_id, evidence_refs, now=None)`
+   - requires producer's active execution lease;
+   - writes immutable `produced_by` on first submission;
+   - persists packet/evidence references;
+   - clears execution claim/lease;
+   - enters `verifying`;
+   - appends `producer_completion_submitted`.
+
+2. `claim_verification(task_id, verifier_worker_id, lease_seconds=900, now=None)`
+   - requires `verifying`;
+   - rejects `verifier_worker_id == produced_by` as `self_verification_forbidden`;
+   - requires caller eligibility to have been established by the verifier-routing layer;
+   - renews only the owning live verifier lease;
+   - refuses competing live claims;
+   - permits reclaim after expiry without incrementing producer `attempt`;
+   - appends `verification_claimed` / `verification_lease_renewed`.
+
+3. `accept_verification(task_id, verifier_worker_id, evidence_refs, next_status='completed', now=None)`
+   - requires active unexpired verifier lease owned by caller;
+   - only allows a pre-authorized safe local post-verification state;
+   - clears verifier claim/lease;
+   - appends `verification_accepted`;
+   - never grants/proposes merge, deploy, external-post, credential, private-data, or runtime authority.
+
+4. `reject_verification(task_id, verifier_worker_id, reason, evidence_refs, max_rejections, require_human=False, now=None)`
+   - requires active unexpired verifier lease owned by caller;
+   - preserves producer packet/evidence;
+   - increments bounded verification rejection count, not producer execution attempt;
+   - requeues only while policy permits; otherwise routes to `blocked` or `human_review`;
+   - clears verifier claim/lease;
+   - appends `verification_rejected` with bounded metadata.
+
+5. `reap_expired_verification(now=None)`
+   - clears only expired verifier claims;
+   - preserves `produced_by`, completion packet/evidence, producer attempt count, and `verifying` state;
+   - appends `verification_lease_expired`.
+
+## Invariants
+
+- `claim()` remains unable to acquire `verifying` work.
+- Producer execution attempt count is changed only by execution acquisition, never verifier claim/reclaim/rejection.
+- `produced_by` cannot be silently replaced by a later verifier or retry path.
+- Acceptance/rejection by a stale or non-owner worker fails closed with no state mutation.
+- Human/governance gates are not satisfiable by verifier approval.
+- Verification APIs do not mutate objective, risk class, source/private-data scope, deployment authority, or acceptance criteria.
+- Existing event ordering remains sufficient to reconstruct producer submission, verifier claims/expiry, decision, and resulting state.
+
+## Test mapping
+
+Implement the reviewed contract's ten tests directly against a temporary SQLite ledger. Add explicit assertions that producer packet/evidence survive rejection and expired-verifier reclaim, that producer `attempt` is unchanged by verification operations, and that event order reconstructs the lifecycle without external state.
+
+## Migration constraint
+
+Because `_init_schema()` currently uses `CREATE TABLE IF NOT EXISTS`, adding columns only to the CREATE statement is insufficient for an existing SQLite file. The implementation must use an idempotent local migration (for example `PRAGMA table_info(tasks)` plus bounded `ALTER TABLE ... ADD COLUMN` for missing columns) and add a regression test opening a pre-extension ledger schema. Do not drop/recreate the table or discard historical events.
+
+## Handoff
+
+Next bounded implementation step: add the idempotent schema migration and the five ledger operations above, then implement the ten contract tests plus the existing-ledger migration regression. Keep PR #15 draft/unmerged until exact-head CI and independent review pass.
+
+No provider invocation, Guardian runtime wiring, subprocess/network execution, merge, deployment, external posting, credential/private-chat access, destructive archive action, or authority expansion is authorized by this design.

--- a/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-migration-tests-run-013.md
+++ b/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-migration-tests-run-013.md
@@ -1,0 +1,25 @@
+# AUTOPILOT-004 verifier migration test checkpoint
+
+Status: implementation-driving regression checkpoint
+Scope: PR #15 / `autopilot-004-verifier-lifecycle-impl`
+
+## Durable change
+
+Added `tests/test_autopilot_verifier_ledger_migration.py` to pin the additive SQLite migration requirement before implementation.
+
+The regression fixture creates the exact pre-verifier `tasks`/`events` shape, including an existing task with `attempt=2` and an existing audit event. Opening that database through `TaskLedger` is required to:
+
+- add the six verifier lifecycle columns without dropping/recreating the task table;
+- preserve the existing task payload, status, attempt count, and event detail;
+- remain idempotent when the same ledger is opened again;
+- avoid duplicate migration columns or synthetic history loss.
+
+## Expected current state
+
+These tests are specification-first and are expected to fail on the current implementation because `_init_schema()` still lacks the additive migration. They must not be treated as acceptance evidence until the implementation lands and exact-head CI passes.
+
+## Handoff
+
+Next bounded step: implement the idempotent migration in `TaskLedger._init_schema()` using schema introspection plus additive `ALTER TABLE ... ADD COLUMN` operations, then run/verify these tests. After migration is green, implement verifier submit/claim/accept/reject/reap operations and the remaining lifecycle contract tests.
+
+No provider invocation, Guardian runtime wiring, network/subprocess execution, merge, deployment, external posting, credential/private-chat access, destructive archive action, or authority expansion was performed.

--- a/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-submit-claim-run-019.md
+++ b/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-submit-claim-run-019.md
@@ -1,0 +1,22 @@
+# AUTOPILOT-004 verifier submit/claim implementation checkpoint
+
+Status: bounded implementation checkpoint
+Scope: PR #15 / `autopilot-004-verifier-lifecycle-impl`
+
+## Durable change
+Implemented the first two persistent verifier lifecycle operations in the existing SQLite `TaskLedger`:
+
+- `submit_for_verification(...)` requires the producer's live execution lease, immutably binds `produced_by`, persists packet/evidence references, clears the execution lease, enters `verifying`, and records `producer_completion_submitted`.
+- `claim_verification(...)` uses a separate verifier lease, forbids producer self-verification, refuses competing live verifier claims, permits owned renewal and expired-lease replacement, and does not increment the producer execution attempt count.
+- `get(...)` now exposes the bounded verifier lifecycle fields needed for deterministic tests and audit inspection.
+
+Implementation commit: `a5be458c024b603914f6df5b5270b3923a743552`.
+
+## Safety boundary
+This remains local SQLite state-transition code only. It does not invoke providers, execute Guardian runtime code, merge/deploy, post externally, access credentials/private chatlogs, or expand private-data authority.
+
+## Verification status
+No passing-test claim is made in this checkpoint. Existing lifecycle tests should now exercise submit/claim behavior; exact-head test evidence is still required.
+
+## Handoff
+Next bounded step: implement active-owner `accept_verification`, bounded `reject_verification`, and `reap_expired_verification`, preserving producer packet/evidence and attempt counts. Then run the migration plus ten lifecycle tests on the exact PR head and keep PR #15 draft until independent review confirms the authority boundary.

--- a/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-trusted-claim-run-021.md
+++ b/elysia_collective_seed/autopilot/handoffs/AUTOPILOT-004-verifier-trusted-claim-run-021.md
@@ -1,0 +1,53 @@
+# AUTOPILOT-004 trusted verifier-claim handoff — run 021
+
+## Task
+
+- Sources: issues #8, #17; draft PR #15; master control issue #11.
+- Starting SHA: `a6ae745f1063a5dc80a1f073bd60174462726e35`.
+- Objective: perform the final authority review requested by run 020 and repair
+  any falsifiable verifier-claim bypass without enabling the runtime.
+
+## Independent findings
+
+Two independent reviewers reproduced that the prior public
+`VerificationDecision` could be fabricated or replayed and that
+`select_verifier()` trusted a spoofable producer-group argument. A first
+process-local tag proposal was rejected during review because callers could
+launder fabricated registry data through the signing function and because
+eligibility could become stale before claim.
+
+## Implementation
+
+- `TaskLedger` now owns the verifier worker registry and independence-group
+  mapping used for claims.
+- `claim_verification()` recomputes eligibility inside the ledger transaction
+  against the complete current registry. It requires the requester to be the
+  deterministic selected worker and rechecks availability, independence,
+  task-required capabilities, and task risk class at claim/renewal time.
+- `select_verifier()` fails closed when the claimed producer group is absent
+  from or disagrees with the supplied registry.
+- Caller-supplied authorization decisions were removed from the authoritative
+  claim API, closing fabricated and stale-decision replay paths.
+- Tests now cover spoofed producer metadata, current-registry changes,
+  task-specific capability/risk requirements, exhausted retry routing to
+  `human_review`, protected task metadata, and persisted audit reconstruction.
+
+The registries are trusted local orchestrator configuration, not a hostile
+same-process security boundary. This remains runtime-disabled SQLite state
+transition code and grants no provider, merge, deploy, external-post,
+credential, private-data, or Guardian runtime authority.
+
+## Verification
+
+- Focused verifier/migration/lifecycle suite: 17 passed.
+- CI-equivalent `python -m pytest -q elysia_collective_seed`: 43 passed.
+- Compileall for implementation and test surfaces: passed.
+- `git diff --check`: passed; Git emitted line-ending conversion warnings only.
+- Independent adversarial review was requested after the final patch.
+
+## Next gate
+
+Push this isolated branch and obtain exact-head CI. Keep PR #15 draft and
+unmerged until the final independent review and exact-head workflow are green.
+No integration, provider activation, deployment, or protected action is
+authorized by this handoff.

--- a/elysia_collective_seed/autopilot/handoffs/PR15-lifecycle-repair-20260910.md
+++ b/elysia_collective_seed/autopilot/handoffs/PR15-lifecycle-repair-20260910.md
@@ -1,0 +1,46 @@
+# PR #15 lifecycle repair handoff
+
+Status: implementation complete; independent Vega re-verification requested.
+Target: `autopilot-004-verifier-lifecycle-impl`, issues #20, #19, #21 (in that repair order).
+Starting product head: `46f77f5dd0fe594d30b1f3e9e5573c8d7ad37f1e`.
+Vega evidence/tests retained from `1326aa7` without changes.
+Implementer: Codex; separate from the requested final Vega verifier.
+
+## Changes and policy
+
+1. **#20:** Generic release cannot complete consequential writes or unknown-risk work, and requires the current unexpired execution lease. Direct read-only completion remains available only without human, review-role, required-check or verification-capability gates. Generic release cannot create a metadata-free `verifying` row. Producer submission is the only execution-to-verification transition.
+2. **#19:** Two additive SQLite columns snapshot execution and rejection budgets. Execution policy is validated from the admitted task's positive integer max_attempts (default 3); verification uses the persisted system ceiling of 2. The legacy max_rejections argument remains accepted for source compatibility but is ignored, including attempts to raise or lower it. Acquisition checks and mutation execute under BEGIN IMMEDIATE. Exhausted acquisition, retry release/reap and rejection route to human_review; live last-attempt renewal and successful verification remain permitted. Invalid legacy limits yield zero budget and fail closed on acquisition. Existing historical rows/events are retained.
+3. **#21:** Successful validated completion calls submit_for_verification, binds the current live producer lease, and persists producer ID, supplied packet ID (or deterministic SHA-256 ID for legacy packets), evidence references and check results. Submission audit records include attempt and producer lease expiry. Required checks come from the persisted task as well as caller requirements. Explicit packet/evidence fields are represented in the completion schema and malformed evidence is refused.
+4. CI explicitly collects the verifier, migration, lifecycle, unchanged Vega and repair suites alongside seed tests. PRs targeting autopilot branches trigger the workflow, and checkout selects the exact source head rather than a synthetic merge ref.
+
+**Admission boundary:** put_task is initial trusted task admission, not a worker permission-granting operation. Subsequent upserts preserve the entire original payload and status, including queued metadata; they only update timestamp and append an event recording actual/requested status. This prevents callers changing risk, retry policy, required checks or state through an upsert. There is no new authority-changing update API. Direct SQLite mutation and arbitrary hostile Python code in the orchestrator process are not security boundaries claimed by this patch.
+
+## Files read and changed
+
+Read AGENTS.md, Vega report/tests, PR metadata, lifecycle/state/orchestrator contracts, task/completion schemas, ledger/dispatcher/bridge/validator, seed and root verifier/migration/lifecycle tests, and CI workflow. Changes are restricted to task_ledger.py, dryrun_orchestrator.py, completion_validator.py, completion_packet_schema.json, CI, new repair regressions, one seed-test setup, and this handoff.
+
+The existing stale-payload regression previously created a completed write through the forbidden release bypass. Its setup now submits and independently verifies the write; all original stale-input assertions remain. Vega's six tests and existing root lifecycle/migration/selector tests are unchanged. No tests are skipped or xfailed.
+
+## Validation
+
+Python 3.12.14 / pytest 9.1.1 on Windows. Full acceptance suite before commit: **92 passed** (43 seed, 17 existing focused, 6 Vega, 26 repair).
+
+```text
+python -m pytest -q elysia_collective_seed tests/test_autopilot_verifier.py tests/test_autopilot_verifier_ledger_migration.py tests/test_autopilot_verifier_lifecycle.py tests/test_vega_verifier_boundaries.py tests/test_autopilot_lifecycle_repairs.py
+python -m compileall -q elysia_collective_seed tests/test_autopilot_lifecycle_repairs.py
+git diff --check
+```
+
+Local runner: `C:/Users/Owner/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/python.exe`; PYTHONPATH points to existing isolated `.worktrees/vega-test-15/.vega-deps`, PYTEST_DISABLE_PLUGIN_AUTOLOAD=1, with fresh worktree-local basetemp. Elevated test execution is necessary for this machine's dependency-file ACLs; tests use only synthetic SQLite, no providers or live runtime.
+
+New regressions cover unknown/write/read-only release, stale lease denial, immutable admission policy, malformed retry limits, concurrent expired acquisition, persisted rejection ceilings regardless of caller argument, packet/check/evidence/lease provenance across reopen, deterministic legacy packet identity, persisted required checks, malformed evidence, expired completion and legacy migration/retry preservation.
+
+An independent pre-handoff agent reviewed the working diff and separately ran all 6 Vega plus 26 repair cases: **32 passed**, no blocking findings. This is not final exact-head Vega certification. Final commit SHA, post-commit test result and hosted exact-head CI receipt will be posted on PR #15 and master issue #11 after publication, avoiding a self-referential commit hash in this file.
+
+## Independent Vega request
+
+Verify the published exact PR head against all three issues and the unchanged 1326aa7 falsification cases. Specifically attempt release/upsert bypasses, rejection-limit overrides, expired and concurrent acquisitions, database reopen, required-check omission and validated producer-to-independent-verifier acceptance. Confirm event provenance survives rejection/retry and that CI collects the root tests. Record PASS/FAIL/PARTIAL/BLOCKED/NEEDS_REVIEW independently. Keep issues open pending that verdict.
+
+## Limits and next action
+
+No providers, Guardian runtime wiring, merges, deployment, permission expansion or unrelated features were added. This patch does not certify all Guardian governance. The prior verifier-claim/accept concurrency question and process-local registry trust remain outside these three repairs. If Vega confirms these repairs, queue any separate verified defects as bounded tasks; do not broaden this patch or activate the runtime.

--- a/elysia_collective_seed/autopilot/handoffs/VEGA-PR15-20260910.md
+++ b/elysia_collective_seed/autopilot/handoffs/VEGA-PR15-20260910.md
@@ -1,0 +1,101 @@
+## VEGA VERIFICATION
+
+### TARGET
+
+PR #15, `autopilot-004-verifier-lifecycle-impl`, exact commit
+`46f77f5dd0fe594d30b1f3e9e5573c8d7ad37f1e`; base `e57b04a7db69668de933b7ceccb45c46fa9e8c62`.
+Issues #8, #16, #17, #19 and master control #11. Independently checked the current GitHub head twice; unchanged.
+Test branch: `codex/vega-test-15-verifier-boundaries`.
+
+### CLAIMS TESTED
+
+- Additive legacy migration and idempotency: PASS in existing executable tests.
+- Independent selector and current-registry eligibility checks: PASS in existing tests.
+- Direct submit/claim/accept/reject/reap and persisted evidence: ordinary cases PASS.
+- Rerouted producer provenance and stale producer/current producer self-review refusal: PASS, including new test.
+- Ledger-owned bounded execution and verification retries: FAIL.
+- Producer cannot self-complete consequential writes through public ledger methods: FAIL.
+- Validated completion can proceed to independent verification: FAIL.
+- Runtime/provider activation remains disabled: consistent with inspected local code; no live integration claimed or exercised.
+
+### TESTS EXECUTED
+
+Working directory is this isolated worktree. Python 3.12.14, pytest 9.1.1, Windows.
+Runner: `C:/Users/Owner/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/python.exe`.
+Set `PYTHONPATH` to the worktree's `.vega-deps` and `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`.
+
+| Command (using the runner above as python) | Purpose | Result |
+| --- | --- | --- |
+| `python -m pytest -q elysia_collective_seed tests/test_autopilot_verifier.py tests/test_autopilot_verifier_ledger_migration.py tests/test_autopilot_verifier_lifecycle.py --basetemp .vega-tmp-baseline` | Existing seed regression plus focused verifier/migration suite | 60 passed (43 seed + 17 focused), 0.64s |
+| `python -m pytest -q tests/test_vega_verifier_boundaries.py --basetemp .vega-tmp-boundaries` | Independent public-method/restart/integration falsification | 5 failed, 1 passed, 0.21s |
+| `git diff --check` | Tracked patch whitespace | PASS |
+| `git diff e57b04a 46f77f5` plus source/call-site inspection | Complete PR scope, contracts, tests and integration | Findings below |
+
+Environment failures were resolved before tests: existing venv executable inaccessible; bundled Python lacked pytest; sandbox network/file access prevented installation/import. Installed pytest only into isolated `.vega-deps` and ran the synthetic suites with approved elevated execution. These setup errors are not product failures. No live Guardian boot, credentials, providers, or deployment were exercised.
+
+### NEW TESTS
+
+`tests/test_vega_verifier_boundaries.py` contains six cases:
+
+1. Released task with max_attempts=1 cannot acquire attempt 2 after SQLite reopen.
+2. Expired task with max_attempts=1 cannot acquire attempt 2 after reopen.
+3. Rejection ceiling cannot change from 2 to 9999 across reopen to defer review.
+4. Producer release cannot directly complete a repo_write task.
+5. Validated completed packet must reach eligible independent verifier and acceptance.
+6. Reroute refuses old producer and new producer self-review while preserving both evidence events.
+
+Tests 1-5 fail with product assertions; test 6 passes. No product code changed; failures are deliberately retained without xfail or weakening assertions.
+
+### RUNTIME REACHABILITY
+
+The implemented local chain is `TaskLedger.submit_for_verification -> claim_verification -> select_verifier -> accept/reject -> SQLite state/events`; direct tests exercise it.
+
+The existing orchestration chain is `dispatch_and_claim -> validate_and_apply_completion -> TaskLedger.release`. At `dryrun_orchestrator.py:146`, completed packets call release(verifying), not submit_for_verification. This produces a verifying row with null produced_by/packet ID and empty evidence. With a complete eligible registry, claim_verification returns verification_registry_missing. Thus the local bridge cannot complete the new lifecycle.
+
+Static search found no seed/autopilot references in inspected Guardian/Elysia Python runtime trees or run_guardian.py/run_elysia.py. Guardian integration is explicitly excluded by the PR and is not a defect by itself. This is not a whole-repository/runtime readiness verdict.
+
+### FAILURES
+
+**F1 HIGH — execution retry ceiling bypass (#19).** `task_ledger.py:107`, acquisition at line 114: max_attempts=1 permits a second acquisition with attempt=2 after release or expiry and database reopen. Expected denial before increment. Failure class: policy absent from authoritative state transition.
+
+**F2 HIGH — caller-selected verification retry policy (#19).** `task_ledger.py:180`: after one rejection with ceiling 2, reopen and reject again with 9999; status remains queued and rejection count is 2. Expected caller cannot raise established/system policy to defer escalation. No durable verification policy field currently exists; this test captures that missing policy rather than claiming a schema field exists.
+
+**F3 HIGH — producer self-completion bypass.** `task_ledger.py:201`: claim a repo_write task, then release(next_status='completed'); returns true and stores completed with only task_upserted/task_claimed/task_released events, no independent acceptance. Expected refusal or governed transition. Inherited release behavior remains an open bypass around the new verification gate; this is not claimed to be newly introduced by PR #15.
+
+**F4 HIGH — validated completion disconnected from verifier lifecycle.** `dryrun_orchestrator.py:146`: validated completion reports applied/verifying but drops producer/evidence metadata; eligible verifier claim is denied. Expected persisted provenance and successful independent claim. Failure class: missing integration between existing bridge and new ledger API.
+
+**Verification gap:** `.github/workflows/elysia-autopilot-ci.yml:52` runs only `pytest -q elysia_collective_seed`, omitting all 17 root tests introduced by this PR and Vega's new tests. Green seed CI does not establish verifier acceptance. PR body also refers to stale a694f42 and says several now-implemented operations remain missing; use exact code and latest handoff instead.
+
+### FALSE CAPABILITIES
+
+No placeholder/stub implementation was established in the reviewed new methods. Do not label intentionally disabled Guardian integration FALSE_CAPABILITY. An operational end-to-end verifier-routing claim would be FALSE_CAPABILITY at the existing bridge: state label verifying is produced, but the verifier cannot acquire the resulting task. PR scope and historical handoffs already describe incomplete integration; this report does not attribute a broader production-ready claim to them.
+
+### SAFETY CHECKS
+
+Direct selector self/same-group/missing/spoofed metadata rejection, stale/wrong verifier decisions, migration retention, expiry evidence and current producer identity checks pass in executed suites. Anti-loop ceilings and public-method producer self-completion fail. No merge/deploy/provider/private-data authority was activated. Registry remains trusted process-local configuration, not a hostile-process security boundary. Concurrent claim/accept races and malformed durable state were not covered by this bounded pass.
+
+### VERDICT
+
+FAIL
+
+### CONFIDENCE
+
+0.99 for the reproduced failures at the target commit; not a probability of overall Guardian health.
+
+### ASTRA REPAIR TASK
+
+1. Existing #19: enforce immutable validated retry ceilings atomically in acquisition/rejection, including reopen and expired leases. Preserve audit history.
+2. Close general release's self-completion bypass for consequential writes; require independent acceptance and a live authorized transition. Keep read-only policy explicit.
+3. Route validated successful completion through producer submission, persist packet/evidence identity, and exercise through verifier acceptance. Include root verifier and boundary tests in CI. Remain runtime-disabled.
+
+Each failing test above is a bounded reproduction. Do not merge or enable providers as part of repairs. Re-run the 60 baseline tests and all six Vega cases against the repair head.
+
+### EREBUS QUESTIONS
+
+- Which public ledger methods are trusted administrative operations, and which enforce worker-facing authority? Can alternate methods defeat the advertised invariants?
+- How is task policy made immutable across put_task upserts and restart?
+- Can concurrent verifier transactions interleave between SELECT eligibility and UPDATE ownership? The connection context alone does not begin a transaction on SELECT.
+
+### NEXT TEST PRIORITY
+
+Repair and re-test F3/#19 first, then F4 through the public bridge. Add deterministic two-connection verifier claim/accept race tests before treating atomic-claim language as proven. Older open PRs #12/#4 and specification lanes were not independently re-verified in this pass; #18 remains preservation-only.

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -63,7 +63,13 @@ class TaskLedger:
                 attempt INTEGER NOT NULL DEFAULT 0,
                 claimed_by TEXT,
                 lease_expires_at TEXT,
-                updated_at TEXT NOT NULL
+                updated_at TEXT NOT NULL,
+                produced_by TEXT,
+                completion_packet_id TEXT,
+                completion_evidence_json TEXT,
+                verification_claimed_by TEXT,
+                verification_lease_expires_at TEXT,
+                verification_rejections INTEGER NOT NULL DEFAULT 0
             );
             CREATE TABLE IF NOT EXISTS events (
                 event_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -76,6 +82,21 @@ class TaskLedger:
             );
             """
         )
+        # Existing ledgers predate verifier lifecycle columns. CREATE TABLE IF NOT
+        # EXISTS does not upgrade them, so migrate additively and idempotently.
+        # Never drop/recreate tasks: historical task/event state is evidence.
+        existing = {row["name"] for row in self.conn.execute("PRAGMA table_info(tasks)")}
+        verifier_columns = (
+            ("produced_by", "TEXT"),
+            ("completion_packet_id", "TEXT"),
+            ("completion_evidence_json", "TEXT"),
+            ("verification_claimed_by", "TEXT"),
+            ("verification_lease_expires_at", "TEXT"),
+            ("verification_rejections", "INTEGER NOT NULL DEFAULT 0"),
+        )
+        for name, definition in verifier_columns:
+            if name not in existing:
+                self.conn.execute(f"ALTER TABLE tasks ADD COLUMN {name} {definition}")
         self.conn.commit()
 
     def put_task(self, task: Mapping) -> None:

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -54,145 +54,125 @@ class TaskLedger:
         self.conn.close()
 
     def _init_schema(self) -> None:
-        self.conn.executescript(
-            """
+        self.conn.executescript("""
             CREATE TABLE IF NOT EXISTS tasks (
-                task_id TEXT PRIMARY KEY,
-                payload_json TEXT NOT NULL,
-                status TEXT NOT NULL,
-                attempt INTEGER NOT NULL DEFAULT 0,
-                claimed_by TEXT,
-                lease_expires_at TEXT,
-                updated_at TEXT NOT NULL,
-                produced_by TEXT,
-                completion_packet_id TEXT,
-                completion_evidence_json TEXT,
-                verification_claimed_by TEXT,
+                task_id TEXT PRIMARY KEY, payload_json TEXT NOT NULL, status TEXT NOT NULL,
+                attempt INTEGER NOT NULL DEFAULT 0, claimed_by TEXT, lease_expires_at TEXT,
+                updated_at TEXT NOT NULL, produced_by TEXT, completion_packet_id TEXT,
+                completion_evidence_json TEXT, verification_claimed_by TEXT,
                 verification_lease_expires_at TEXT,
                 verification_rejections INTEGER NOT NULL DEFAULT 0
             );
             CREATE TABLE IF NOT EXISTS events (
-                event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                task_id TEXT NOT NULL,
-                event_type TEXT NOT NULL,
-                actor TEXT,
-                detail_json TEXT NOT NULL,
-                created_at TEXT NOT NULL,
-                FOREIGN KEY(task_id) REFERENCES tasks(task_id)
+                event_id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL,
+                event_type TEXT NOT NULL, actor TEXT, detail_json TEXT NOT NULL,
+                created_at TEXT NOT NULL, FOREIGN KEY(task_id) REFERENCES tasks(task_id)
             );
-            """
-        )
+        """)
         existing = {row["name"] for row in self.conn.execute("PRAGMA table_info(tasks)")}
-        verifier_columns = (
-            ("produced_by", "TEXT"),
-            ("completion_packet_id", "TEXT"),
-            ("completion_evidence_json", "TEXT"),
-            ("verification_claimed_by", "TEXT"),
-            ("verification_lease_expires_at", "TEXT"),
-            ("verification_rejections", "INTEGER NOT NULL DEFAULT 0"),
-        )
-        for name, definition in verifier_columns:
+        for name, definition in (("produced_by","TEXT"),("completion_packet_id","TEXT"),("completion_evidence_json","TEXT"),("verification_claimed_by","TEXT"),("verification_lease_expires_at","TEXT"),("verification_rejections","INTEGER NOT NULL DEFAULT 0")):
             if name not in existing:
                 self.conn.execute(f"ALTER TABLE tasks ADD COLUMN {name} {definition}")
         self.conn.commit()
 
     def put_task(self, task: Mapping) -> None:
-        task_id = str(task["task_id"])
-        status = str(task.get("status", "queued"))
-        now = _iso(_utcnow())
-        payload = json.dumps(dict(task), sort_keys=True)
+        task_id=str(task["task_id"]); status=str(task.get("status","queued")); now=_iso(_utcnow()); payload=json.dumps(dict(task),sort_keys=True)
         with self.conn:
-            self.conn.execute(
-                """INSERT INTO tasks(task_id,payload_json,status,attempt,updated_at)
-                   VALUES(?,?,?,?,?)
-                   ON CONFLICT(task_id) DO UPDATE SET
-                     payload_json=excluded.payload_json,
-                     status=CASE WHEN tasks.status IN ('claimed','running','verifying','review','blocked','human_review','completed','rejected','archived')
-                                 THEN tasks.status ELSE excluded.status END,
-                     updated_at=excluded.updated_at""",
-                (task_id, payload, status, int(task.get("attempt", 0)), now),
-            )
-            self._event(task_id, "task_upserted", "ledger", {"status": status}, now)
+            self.conn.execute("""INSERT INTO tasks(task_id,payload_json,status,attempt,updated_at) VALUES(?,?,?,?,?)
+            ON CONFLICT(task_id) DO UPDATE SET payload_json=excluded.payload_json,
+            status=CASE WHEN tasks.status IN ('claimed','running','verifying','review','blocked','human_review','completed','rejected','archived') THEN tasks.status ELSE excluded.status END,
+            updated_at=excluded.updated_at""",(task_id,payload,status,int(task.get("attempt",0)),now))
+            self._event(task_id,"task_upserted","ledger",{"status":status},now)
 
     def get(self, task_id: str) -> dict | None:
-        row = self.conn.execute("SELECT * FROM tasks WHERE task_id=?", (task_id,)).fetchone()
-        if not row:
-            return None
-        result = json.loads(row["payload_json"])
-        result.update({
-            "status": row["status"], "attempt": row["attempt"],
-            "claimed_by": row["claimed_by"], "lease_expires_at": row["lease_expires_at"],
-            "produced_by": row["produced_by"], "completion_packet_id": row["completion_packet_id"],
-            "completion_evidence": json.loads(row["completion_evidence_json"] or "[]"),
-            "verification_claimed_by": row["verification_claimed_by"],
-            "verification_lease_expires_at": row["verification_lease_expires_at"],
-            "verification_rejections": row["verification_rejections"],
-        })
+        row=self.conn.execute("SELECT * FROM tasks WHERE task_id=?",(task_id,)).fetchone()
+        if not row: return None
+        result=json.loads(row["payload_json"])
+        result.update({"status":row["status"],"attempt":row["attempt"],"claimed_by":row["claimed_by"],"lease_expires_at":row["lease_expires_at"],"produced_by":row["produced_by"],"completion_packet_id":row["completion_packet_id"],"completion_evidence":json.loads(row["completion_evidence_json"] or "[]"),"verification_claimed_by":row["verification_claimed_by"],"verification_lease_expires_at":row["verification_lease_expires_at"],"verification_rejections":row["verification_rejections"]})
         return result
 
-    def claim(self, task_id: str, worker_id: str, lease_seconds: int = 900, now: datetime | None = None) -> ClaimResult:
-        if lease_seconds <= 0:
-            raise ValueError("lease_seconds must be positive")
-        now = now or _utcnow(); now_s = _iso(now); expires = _iso(now + timedelta(seconds=lease_seconds))
+    def claim(self, task_id: str, worker_id: str, lease_seconds: int=900, now: datetime|None=None) -> ClaimResult:
+        if lease_seconds<=0: raise ValueError("lease_seconds must be positive")
+        now=now or _utcnow(); now_s=_iso(now); expires=_iso(now+timedelta(seconds=lease_seconds))
         with self.conn:
-            renewed = self.conn.execute("""UPDATE tasks SET status='claimed', lease_expires_at=?, updated_at=? WHERE task_id=? AND claimed_by=? AND lease_expires_at IS NOT NULL AND lease_expires_at>? AND status IN ('claimed','running')""", (expires, now_s, task_id, worker_id, now_s))
-            if renewed.rowcount == 1:
-                self._event(task_id, "lease_renewed", worker_id, {"expires": expires}, now_s); return ClaimResult(True, task_id, worker_id, "renewed", expires)
-            acquired = self.conn.execute("""UPDATE tasks SET status='claimed', attempt=attempt+1, claimed_by=?, lease_expires_at=?, updated_at=? WHERE task_id=? AND ((status='queued' AND (claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=?)) OR (status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at<=?))""", (worker_id, expires, now_s, task_id, now_s, now_s))
-            if acquired.rowcount == 1:
-                self._event(task_id, "task_claimed", worker_id, {"expires": expires}, now_s); return ClaimResult(True, task_id, worker_id, "claimed", expires)
-            row = self.conn.execute("SELECT * FROM tasks WHERE task_id=?", (task_id,)).fetchone()
-            if not row: return ClaimResult(False, task_id, worker_id, "task_not_found")
-            if row["status"] in TERMINAL_STATES: return ClaimResult(False, task_id, worker_id, "terminal_task")
-            if row["status"] != "queued": return ClaimResult(False, task_id, worker_id, "state_not_claimable", row["lease_expires_at"])
-            return ClaimResult(False, task_id, worker_id, "active_lease", row["lease_expires_at"])
+            renewed=self.conn.execute("UPDATE tasks SET status='claimed',lease_expires_at=?,updated_at=? WHERE task_id=? AND claimed_by=? AND lease_expires_at IS NOT NULL AND lease_expires_at>? AND status IN ('claimed','running')",(expires,now_s,task_id,worker_id,now_s))
+            if renewed.rowcount==1:
+                self._event(task_id,"lease_renewed",worker_id,{"expires":expires},now_s); return ClaimResult(True,task_id,worker_id,"renewed",expires)
+            acquired=self.conn.execute("UPDATE tasks SET status='claimed',attempt=attempt+1,claimed_by=?,lease_expires_at=?,updated_at=? WHERE task_id=? AND ((status='queued' AND (claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=?)) OR (status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at<=?))",(worker_id,expires,now_s,task_id,now_s,now_s))
+            if acquired.rowcount==1:
+                self._event(task_id,"task_claimed",worker_id,{"expires":expires},now_s); return ClaimResult(True,task_id,worker_id,"claimed",expires)
+            row=self.conn.execute("SELECT * FROM tasks WHERE task_id=?",(task_id,)).fetchone()
+            if not row: return ClaimResult(False,task_id,worker_id,"task_not_found")
+            if row["status"] in TERMINAL_STATES: return ClaimResult(False,task_id,worker_id,"terminal_task")
+            if row["status"]!="queued": return ClaimResult(False,task_id,worker_id,"state_not_claimable",row["lease_expires_at"])
+            return ClaimResult(False,task_id,worker_id,"active_lease",row["lease_expires_at"])
 
-    def submit_for_verification(self, task_id: str, producer_worker_id: str, packet_id: str, evidence_refs: list[str], now: datetime | None = None) -> bool:
-        """Persist producer evidence and surrender the execution lease for review."""
-        now = now or _utcnow(); now_s = _iso(now)
-        evidence_json = json.dumps(list(evidence_refs), sort_keys=True)
+    def submit_for_verification(self, task_id: str, producer_worker_id: str, packet_id: str, evidence_refs: list[str], now: datetime|None=None) -> bool:
+        now=now or _utcnow(); now_s=_iso(now); evidence_json=json.dumps(list(evidence_refs),sort_keys=True)
         with self.conn:
-            row = self.conn.execute("SELECT produced_by FROM tasks WHERE task_id=?", (task_id,)).fetchone()
-            if not row or (row["produced_by"] is not None and row["produced_by"] != producer_worker_id):
-                return False
-            cursor = self.conn.execute("""UPDATE tasks SET status='verifying', produced_by=COALESCE(produced_by,?), completion_packet_id=?, completion_evidence_json=?, claimed_by=NULL, lease_expires_at=NULL, verification_claimed_by=NULL, verification_lease_expires_at=NULL, updated_at=? WHERE task_id=? AND claimed_by=? AND status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at>?""", (producer_worker_id, packet_id, evidence_json, now_s, task_id, producer_worker_id, now_s))
-            if cursor.rowcount != 1: return False
-            self._event(task_id, "producer_completion_submitted", producer_worker_id, {"packet_id": packet_id, "evidence_refs": list(evidence_refs)}, now_s)
-            return True
+            row=self.conn.execute("SELECT produced_by FROM tasks WHERE task_id=?",(task_id,)).fetchone()
+            if not row or (row["produced_by"] is not None and row["produced_by"]!=producer_worker_id): return False
+            cursor=self.conn.execute("UPDATE tasks SET status='verifying',produced_by=COALESCE(produced_by,?),completion_packet_id=?,completion_evidence_json=?,claimed_by=NULL,lease_expires_at=NULL,verification_claimed_by=NULL,verification_lease_expires_at=NULL,updated_at=? WHERE task_id=? AND claimed_by=? AND status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at>?",(producer_worker_id,packet_id,evidence_json,now_s,task_id,producer_worker_id,now_s))
+            if cursor.rowcount!=1: return False
+            self._event(task_id,"producer_completion_submitted",producer_worker_id,{"packet_id":packet_id,"evidence_refs":list(evidence_refs)},now_s); return True
 
-    def claim_verification(self, task_id: str, verifier_worker_id: str, lease_seconds: int = 900, now: datetime | None = None) -> ClaimResult:
-        """Acquire or renew a separate verifier lease without changing producer attempts."""
-        if lease_seconds <= 0: raise ValueError("lease_seconds must be positive")
-        now = now or _utcnow(); now_s = _iso(now); expires = _iso(now + timedelta(seconds=lease_seconds))
+    def claim_verification(self, task_id: str, verifier_worker_id: str, lease_seconds: int=900, now: datetime|None=None) -> ClaimResult:
+        if lease_seconds<=0: raise ValueError("lease_seconds must be positive")
+        now=now or _utcnow(); now_s=_iso(now); expires=_iso(now+timedelta(seconds=lease_seconds))
         with self.conn:
-            row = self.conn.execute("SELECT produced_by,verification_claimed_by,verification_lease_expires_at,status FROM tasks WHERE task_id=?", (task_id,)).fetchone()
-            if not row: return ClaimResult(False, task_id, verifier_worker_id, "task_not_found")
-            if row["status"] != "verifying": return ClaimResult(False, task_id, verifier_worker_id, "state_not_verifiable")
-            if row["produced_by"] == verifier_worker_id: return ClaimResult(False, task_id, verifier_worker_id, "self_verification_forbidden")
-            owner = row["verification_claimed_by"]; expiry = _parse(row["verification_lease_expires_at"])
-            if owner == verifier_worker_id and expiry and expiry > now:
-                self.conn.execute("UPDATE tasks SET verification_lease_expires_at=?,updated_at=? WHERE task_id=?", (expires, now_s, task_id)); self._event(task_id, "verification_lease_renewed", verifier_worker_id, {"expires": expires}, now_s); return ClaimResult(True, task_id, verifier_worker_id, "renewed", expires)
-            if owner and expiry and expiry > now: return ClaimResult(False, task_id, verifier_worker_id, "active_verification_lease", row["verification_lease_expires_at"])
-            cursor = self.conn.execute("UPDATE tasks SET verification_claimed_by=?,verification_lease_expires_at=?,updated_at=? WHERE task_id=? AND status='verifying'", (verifier_worker_id, expires, now_s, task_id))
-            if cursor.rowcount != 1: return ClaimResult(False, task_id, verifier_worker_id, "state_not_verifiable")
-            self._event(task_id, "verification_claimed", verifier_worker_id, {"expires": expires}, now_s); return ClaimResult(True, task_id, verifier_worker_id, "claimed", expires)
+            row=self.conn.execute("SELECT produced_by,verification_claimed_by,verification_lease_expires_at,status FROM tasks WHERE task_id=?",(task_id,)).fetchone()
+            if not row: return ClaimResult(False,task_id,verifier_worker_id,"task_not_found")
+            if row["status"]!="verifying": return ClaimResult(False,task_id,verifier_worker_id,"state_not_verifiable")
+            if row["produced_by"]==verifier_worker_id: return ClaimResult(False,task_id,verifier_worker_id,"self_verification_forbidden")
+            owner=row["verification_claimed_by"]; expiry=_parse(row["verification_lease_expires_at"])
+            if owner==verifier_worker_id and expiry and expiry>now:
+                self.conn.execute("UPDATE tasks SET verification_lease_expires_at=?,updated_at=? WHERE task_id=?",(expires,now_s,task_id)); self._event(task_id,"verification_lease_renewed",verifier_worker_id,{"expires":expires},now_s); return ClaimResult(True,task_id,verifier_worker_id,"renewed",expires)
+            if owner and expiry and expiry>now: return ClaimResult(False,task_id,verifier_worker_id,"active_verification_lease",row["verification_lease_expires_at"])
+            self.conn.execute("UPDATE tasks SET verification_claimed_by=?,verification_lease_expires_at=?,updated_at=? WHERE task_id=? AND status='verifying'",(verifier_worker_id,expires,now_s,task_id)); self._event(task_id,"verification_claimed",verifier_worker_id,{"expires":expires},now_s); return ClaimResult(True,task_id,verifier_worker_id,"claimed",expires)
 
-    def release(self, task_id: str, worker_id: str, next_status: str = "queued", now: datetime | None = None) -> bool:
+    def accept_verification(self, task_id: str, verifier_worker_id: str, evidence_refs: list[str], now: datetime|None=None) -> bool:
+        now=now or _utcnow(); now_s=_iso(now)
+        with self.conn:
+            cursor=self.conn.execute("UPDATE tasks SET status='completed',verification_claimed_by=NULL,verification_lease_expires_at=NULL,updated_at=? WHERE task_id=? AND status='verifying' AND verification_claimed_by=? AND verification_lease_expires_at IS NOT NULL AND verification_lease_expires_at>?",(now_s,task_id,verifier_worker_id,now_s))
+            if cursor.rowcount!=1: return False
+            self._event(task_id,"verification_accepted",verifier_worker_id,{"evidence_refs":list(evidence_refs)},now_s); return True
+
+    def reject_verification(self, task_id: str, verifier_worker_id: str, reason: str, evidence_refs: list[str], max_rejections: int=2, now: datetime|None=None) -> bool:
+        if max_rejections<=0: raise ValueError("max_rejections must be positive")
+        now=now or _utcnow(); now_s=_iso(now)
+        with self.conn:
+            row=self.conn.execute("SELECT verification_rejections FROM tasks WHERE task_id=? AND status='verifying' AND verification_claimed_by=? AND verification_lease_expires_at IS NOT NULL AND verification_lease_expires_at>?",(task_id,verifier_worker_id,now_s)).fetchone()
+            if not row: return False
+            count=int(row["verification_rejections"])+1; next_status="human_review" if count>=max_rejections else "queued"
+            self.conn.execute("UPDATE tasks SET status=?,verification_rejections=?,verification_claimed_by=NULL,verification_lease_expires_at=NULL,claimed_by=NULL,lease_expires_at=NULL,updated_at=? WHERE task_id=?",(next_status,count,now_s,task_id))
+            self._event(task_id,"verification_rejected",verifier_worker_id,{"reason":reason,"evidence_refs":list(evidence_refs),"rejections":count,"next_status":next_status},now_s); return True
+
+    def reap_expired_verification(self, now: datetime|None=None) -> list[str]:
+        now=now or _utcnow(); now_s=_iso(now)
+        rows=self.conn.execute("SELECT task_id,verification_claimed_by,verification_lease_expires_at FROM tasks WHERE status='verifying' AND verification_claimed_by IS NOT NULL AND verification_lease_expires_at IS NOT NULL AND verification_lease_expires_at<=? ORDER BY task_id",(now_s,)).fetchall()
+        reaped=[]
+        with self.conn:
+            for row in rows:
+                cursor=self.conn.execute("UPDATE tasks SET verification_claimed_by=NULL,verification_lease_expires_at=NULL,updated_at=? WHERE task_id=? AND status='verifying' AND verification_claimed_by=? AND verification_lease_expires_at=?",(now_s,row["task_id"],row["verification_claimed_by"],row["verification_lease_expires_at"]))
+                if cursor.rowcount==1:
+                    self._event(row["task_id"],"verification_lease_expired",row["verification_claimed_by"],{},now_s); reaped.append(row["task_id"])
+        return reaped
+
+    def release(self, task_id: str, worker_id: str, next_status: str="queued", now: datetime|None=None) -> bool:
         if next_status in ACTIVE_LEASE_STATES: raise ValueError("release next_status cannot retain an active lease state")
-        now_s = _iso(now or _utcnow())
+        now_s=_iso(now or _utcnow())
         with self.conn:
-            cursor = self.conn.execute("UPDATE tasks SET status=?, claimed_by=NULL, lease_expires_at=NULL, updated_at=? WHERE task_id=? AND claimed_by=?", (next_status, now_s, task_id, worker_id))
-            if cursor.rowcount != 1: return False
-            self._event(task_id, "task_released", worker_id, {"status": next_status}, now_s); return True
+            cursor=self.conn.execute("UPDATE tasks SET status=?,claimed_by=NULL,lease_expires_at=NULL,updated_at=? WHERE task_id=? AND claimed_by=?",(next_status,now_s,task_id,worker_id))
+            if cursor.rowcount!=1: return False
+            self._event(task_id,"task_released",worker_id,{"status":next_status},now_s); return True
 
-    def reap_expired(self, now: datetime | None = None) -> list[str]:
-        now = now or _utcnow(); now_s = _iso(now)
-        rows = self.conn.execute("SELECT task_id, claimed_by, lease_expires_at FROM tasks WHERE claimed_by IS NOT NULL AND status IN ('claimed','running')").fetchall()
-        expired = [r for r in rows if (_parse(r["lease_expires_at"]) or now) <= now]
+    def reap_expired(self, now: datetime|None=None) -> list[str]:
+        now=now or _utcnow(); now_s=_iso(now)
+        rows=self.conn.execute("SELECT task_id,claimed_by,lease_expires_at FROM tasks WHERE claimed_by IS NOT NULL AND status IN ('claimed','running')").fetchall(); expired=[r for r in rows if (_parse(r["lease_expires_at"]) or now)<=now]
         with self.conn:
             reaped=[]
             for row in expired:
-                cursor=self.conn.execute("UPDATE tasks SET status='queued', claimed_by=NULL, lease_expires_at=NULL, updated_at=? WHERE task_id=? AND claimed_by=? AND lease_expires_at=? AND status IN ('claimed','running')", (now_s,row["task_id"],row["claimed_by"],row["lease_expires_at"]))
+                cursor=self.conn.execute("UPDATE tasks SET status='queued',claimed_by=NULL,lease_expires_at=NULL,updated_at=? WHERE task_id=? AND claimed_by=? AND lease_expires_at=? AND status IN ('claimed','running')",(now_s,row["task_id"],row["claimed_by"],row["lease_expires_at"]))
                 if cursor.rowcount==1: self._event(row["task_id"],"lease_expired",row["claimed_by"],{},now_s); reaped.append(row["task_id"])
         return reaped
 
@@ -200,5 +180,5 @@ class TaskLedger:
         rows=self.conn.execute("SELECT event_type,actor,detail_json,created_at FROM events WHERE task_id=? ORDER BY event_id",(task_id,)).fetchall()
         return [{"event_type":r["event_type"],"actor":r["actor"],"detail":json.loads(r["detail_json"]),"created_at":r["created_at"]} for r in rows]
 
-    def _event(self, task_id: str, event_type: str, actor: str | None, detail: Mapping, created_at: str) -> None:
+    def _event(self, task_id: str, event_type: str, actor: str|None, detail: Mapping, created_at: str) -> None:
         self.conn.execute("INSERT INTO events(task_id,event_type,actor,detail_json,created_at) VALUES(?,?,?,?,?)",(task_id,event_type,actor,json.dumps(dict(detail),sort_keys=True),created_at))

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -82,9 +82,6 @@ class TaskLedger:
             );
             """
         )
-        # Existing ledgers predate verifier lifecycle columns. CREATE TABLE IF NOT
-        # EXISTS does not upgrade them, so migrate additively and idempotently.
-        # Never drop/recreate tasks: historical task/event state is evidence.
         existing = {row["name"] for row in self.conn.execute("PRAGMA table_info(tasks)")}
         verifier_columns = (
             ("produced_by", "TEXT"),
@@ -123,108 +120,85 @@ class TaskLedger:
             return None
         result = json.loads(row["payload_json"])
         result.update({
-            "status": row["status"],
-            "attempt": row["attempt"],
-            "claimed_by": row["claimed_by"],
-            "lease_expires_at": row["lease_expires_at"],
+            "status": row["status"], "attempt": row["attempt"],
+            "claimed_by": row["claimed_by"], "lease_expires_at": row["lease_expires_at"],
+            "produced_by": row["produced_by"], "completion_packet_id": row["completion_packet_id"],
+            "completion_evidence": json.loads(row["completion_evidence_json"] or "[]"),
+            "verification_claimed_by": row["verification_claimed_by"],
+            "verification_lease_expires_at": row["verification_lease_expires_at"],
+            "verification_rejections": row["verification_rejections"],
         })
         return result
 
     def claim(self, task_id: str, worker_id: str, lease_seconds: int = 900, now: datetime | None = None) -> ClaimResult:
-        """Atomically renew an owned live lease or acquire eligible execution work.
-
-        Fresh acquisition is queued-only. An expired claimed/running lease may be
-        atomically reclaimed as a new attempt without first requiring a separate
-        reap transaction. Review/verifying/blocked states still require an explicit
-        transition before another execution lease may be granted.
-        """
         if lease_seconds <= 0:
             raise ValueError("lease_seconds must be positive")
-        now = now or _utcnow()
-        now_s = _iso(now)
-        expires = _iso(now + timedelta(seconds=lease_seconds))
-
+        now = now or _utcnow(); now_s = _iso(now); expires = _iso(now + timedelta(seconds=lease_seconds))
         with self.conn:
-            renewed = self.conn.execute(
-                """UPDATE tasks SET status='claimed', lease_expires_at=?, updated_at=?
-                   WHERE task_id=? AND claimed_by=?
-                     AND lease_expires_at IS NOT NULL AND lease_expires_at>?
-                     AND status IN ('claimed','running')""",
-                (expires, now_s, task_id, worker_id, now_s),
-            )
+            renewed = self.conn.execute("""UPDATE tasks SET status='claimed', lease_expires_at=?, updated_at=? WHERE task_id=? AND claimed_by=? AND lease_expires_at IS NOT NULL AND lease_expires_at>? AND status IN ('claimed','running')""", (expires, now_s, task_id, worker_id, now_s))
             if renewed.rowcount == 1:
-                self._event(task_id, "lease_renewed", worker_id, {"expires": expires}, now_s)
-                return ClaimResult(True, task_id, worker_id, "renewed", expires)
-
-            acquired = self.conn.execute(
-                """UPDATE tasks
-                   SET status='claimed', attempt=attempt+1, claimed_by=?, lease_expires_at=?, updated_at=?
-                   WHERE task_id=? AND (
-                     (status='queued' AND (claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=?))
-                     OR (status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at<=?)
-                   )""",
-                (worker_id, expires, now_s, task_id, now_s, now_s),
-            )
+                self._event(task_id, "lease_renewed", worker_id, {"expires": expires}, now_s); return ClaimResult(True, task_id, worker_id, "renewed", expires)
+            acquired = self.conn.execute("""UPDATE tasks SET status='claimed', attempt=attempt+1, claimed_by=?, lease_expires_at=?, updated_at=? WHERE task_id=? AND ((status='queued' AND (claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=?)) OR (status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at<=?))""", (worker_id, expires, now_s, task_id, now_s, now_s))
             if acquired.rowcount == 1:
-                self._event(task_id, "task_claimed", worker_id, {"expires": expires}, now_s)
-                return ClaimResult(True, task_id, worker_id, "claimed", expires)
-
+                self._event(task_id, "task_claimed", worker_id, {"expires": expires}, now_s); return ClaimResult(True, task_id, worker_id, "claimed", expires)
             row = self.conn.execute("SELECT * FROM tasks WHERE task_id=?", (task_id,)).fetchone()
-            if not row:
-                return ClaimResult(False, task_id, worker_id, "task_not_found")
-            if row["status"] in TERMINAL_STATES:
-                return ClaimResult(False, task_id, worker_id, "terminal_task")
-            lease_expiry = _parse(row["lease_expires_at"])
-            if row["status"] in ACTIVE_LEASE_STATES and row["claimed_by"] is not None and lease_expiry is not None and lease_expiry > now:
-                return ClaimResult(False, task_id, worker_id, "active_lease", row["lease_expires_at"])
-            if row["status"] != "queued":
-                return ClaimResult(False, task_id, worker_id, "state_not_claimable", row["lease_expires_at"])
+            if not row: return ClaimResult(False, task_id, worker_id, "task_not_found")
+            if row["status"] in TERMINAL_STATES: return ClaimResult(False, task_id, worker_id, "terminal_task")
+            if row["status"] != "queued": return ClaimResult(False, task_id, worker_id, "state_not_claimable", row["lease_expires_at"])
             return ClaimResult(False, task_id, worker_id, "active_lease", row["lease_expires_at"])
 
-    def release(self, task_id: str, worker_id: str, next_status: str = "queued", now: datetime | None = None) -> bool:
-        if next_status in ACTIVE_LEASE_STATES:
-            raise ValueError("release next_status cannot retain an active lease state")
-        now_s = _iso(now or _utcnow())
+    def submit_for_verification(self, task_id: str, producer_worker_id: str, packet_id: str, evidence_refs: list[str], now: datetime | None = None) -> bool:
+        """Persist producer evidence and surrender the execution lease for review."""
+        now = now or _utcnow(); now_s = _iso(now)
+        evidence_json = json.dumps(list(evidence_refs), sort_keys=True)
         with self.conn:
-            cursor = self.conn.execute(
-                """UPDATE tasks SET status=?, claimed_by=NULL, lease_expires_at=NULL, updated_at=?
-                   WHERE task_id=? AND claimed_by=?""",
-                (next_status, now_s, task_id, worker_id),
-            )
-            if cursor.rowcount != 1:
+            row = self.conn.execute("SELECT produced_by FROM tasks WHERE task_id=?", (task_id,)).fetchone()
+            if not row or (row["produced_by"] is not None and row["produced_by"] != producer_worker_id):
                 return False
-            self._event(task_id, "task_released", worker_id, {"status": next_status}, now_s)
+            cursor = self.conn.execute("""UPDATE tasks SET status='verifying', produced_by=COALESCE(produced_by,?), completion_packet_id=?, completion_evidence_json=?, claimed_by=NULL, lease_expires_at=NULL, verification_claimed_by=NULL, verification_lease_expires_at=NULL, updated_at=? WHERE task_id=? AND claimed_by=? AND status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at>?""", (producer_worker_id, packet_id, evidence_json, now_s, task_id, producer_worker_id, now_s))
+            if cursor.rowcount != 1: return False
+            self._event(task_id, "producer_completion_submitted", producer_worker_id, {"packet_id": packet_id, "evidence_refs": list(evidence_refs)}, now_s)
             return True
 
+    def claim_verification(self, task_id: str, verifier_worker_id: str, lease_seconds: int = 900, now: datetime | None = None) -> ClaimResult:
+        """Acquire or renew a separate verifier lease without changing producer attempts."""
+        if lease_seconds <= 0: raise ValueError("lease_seconds must be positive")
+        now = now or _utcnow(); now_s = _iso(now); expires = _iso(now + timedelta(seconds=lease_seconds))
+        with self.conn:
+            row = self.conn.execute("SELECT produced_by,verification_claimed_by,verification_lease_expires_at,status FROM tasks WHERE task_id=?", (task_id,)).fetchone()
+            if not row: return ClaimResult(False, task_id, verifier_worker_id, "task_not_found")
+            if row["status"] != "verifying": return ClaimResult(False, task_id, verifier_worker_id, "state_not_verifiable")
+            if row["produced_by"] == verifier_worker_id: return ClaimResult(False, task_id, verifier_worker_id, "self_verification_forbidden")
+            owner = row["verification_claimed_by"]; expiry = _parse(row["verification_lease_expires_at"])
+            if owner == verifier_worker_id and expiry and expiry > now:
+                self.conn.execute("UPDATE tasks SET verification_lease_expires_at=?,updated_at=? WHERE task_id=?", (expires, now_s, task_id)); self._event(task_id, "verification_lease_renewed", verifier_worker_id, {"expires": expires}, now_s); return ClaimResult(True, task_id, verifier_worker_id, "renewed", expires)
+            if owner and expiry and expiry > now: return ClaimResult(False, task_id, verifier_worker_id, "active_verification_lease", row["verification_lease_expires_at"])
+            cursor = self.conn.execute("UPDATE tasks SET verification_claimed_by=?,verification_lease_expires_at=?,updated_at=? WHERE task_id=? AND status='verifying'", (verifier_worker_id, expires, now_s, task_id))
+            if cursor.rowcount != 1: return ClaimResult(False, task_id, verifier_worker_id, "state_not_verifiable")
+            self._event(task_id, "verification_claimed", verifier_worker_id, {"expires": expires}, now_s); return ClaimResult(True, task_id, verifier_worker_id, "claimed", expires)
+
+    def release(self, task_id: str, worker_id: str, next_status: str = "queued", now: datetime | None = None) -> bool:
+        if next_status in ACTIVE_LEASE_STATES: raise ValueError("release next_status cannot retain an active lease state")
+        now_s = _iso(now or _utcnow())
+        with self.conn:
+            cursor = self.conn.execute("UPDATE tasks SET status=?, claimed_by=NULL, lease_expires_at=NULL, updated_at=? WHERE task_id=? AND claimed_by=?", (next_status, now_s, task_id, worker_id))
+            if cursor.rowcount != 1: return False
+            self._event(task_id, "task_released", worker_id, {"status": next_status}, now_s); return True
+
     def reap_expired(self, now: datetime | None = None) -> list[str]:
-        now = now or _utcnow()
-        now_s = _iso(now)
-        rows = self.conn.execute(
-            "SELECT task_id, claimed_by, lease_expires_at FROM tasks WHERE claimed_by IS NOT NULL AND status IN ('claimed','running')"
-        ).fetchall()
+        now = now or _utcnow(); now_s = _iso(now)
+        rows = self.conn.execute("SELECT task_id, claimed_by, lease_expires_at FROM tasks WHERE claimed_by IS NOT NULL AND status IN ('claimed','running')").fetchall()
         expired = [r for r in rows if (_parse(r["lease_expires_at"]) or now) <= now]
         with self.conn:
-            reaped: list[str] = []
+            reaped=[]
             for row in expired:
-                cursor = self.conn.execute(
-                    """UPDATE tasks SET status='queued', claimed_by=NULL, lease_expires_at=NULL, updated_at=?
-                       WHERE task_id=? AND claimed_by=? AND lease_expires_at=? AND status IN ('claimed','running')""",
-                    (now_s, row["task_id"], row["claimed_by"], row["lease_expires_at"]),
-                )
-                if cursor.rowcount == 1:
-                    self._event(row["task_id"], "lease_expired", row["claimed_by"], {}, now_s)
-                    reaped.append(row["task_id"])
+                cursor=self.conn.execute("UPDATE tasks SET status='queued', claimed_by=NULL, lease_expires_at=NULL, updated_at=? WHERE task_id=? AND claimed_by=? AND lease_expires_at=? AND status IN ('claimed','running')", (now_s,row["task_id"],row["claimed_by"],row["lease_expires_at"]))
+                if cursor.rowcount==1: self._event(row["task_id"],"lease_expired",row["claimed_by"],{},now_s); reaped.append(row["task_id"])
         return reaped
 
     def events(self, task_id: str) -> list[dict]:
-        rows = self.conn.execute(
-            "SELECT event_type,actor,detail_json,created_at FROM events WHERE task_id=? ORDER BY event_id",
-            (task_id,),
-        ).fetchall()
-        return [{"event_type": r["event_type"], "actor": r["actor"], "detail": json.loads(r["detail_json"]), "created_at": r["created_at"]} for r in rows]
+        rows=self.conn.execute("SELECT event_type,actor,detail_json,created_at FROM events WHERE task_id=? ORDER BY event_id",(task_id,)).fetchall()
+        return [{"event_type":r["event_type"],"actor":r["actor"],"detail":json.loads(r["detail_json"]),"created_at":r["created_at"]} for r in rows]
 
     def _event(self, task_id: str, event_type: str, actor: str | None, detail: Mapping, created_at: str) -> None:
-        self.conn.execute(
-            "INSERT INTO events(task_id,event_type,actor,detail_json,created_at) VALUES(?,?,?,?,?)",
-            (task_id, event_type, actor, json.dumps(dict(detail), sort_keys=True), created_at),
-        )
+        self.conn.execute("INSERT INTO events(task_id,event_type,actor,detail_json,created_at) VALUES(?,?,?,?,?)",(task_id,event_type,actor,json.dumps(dict(detail),sort_keys=True),created_at))

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -110,9 +110,10 @@ class TaskLedger:
     def submit_for_verification(self, task_id: str, producer_worker_id: str, packet_id: str, evidence_refs: list[str], now: datetime|None=None) -> bool:
         now=now or _utcnow(); now_s=_iso(now); evidence_json=json.dumps(list(evidence_refs),sort_keys=True)
         with self.conn:
-            row=self.conn.execute("SELECT produced_by FROM tasks WHERE task_id=?",(task_id,)).fetchone()
-            if not row or (row["produced_by"] is not None and row["produced_by"]!=producer_worker_id): return False
-            cursor=self.conn.execute("UPDATE tasks SET status='verifying',produced_by=COALESCE(produced_by,?),completion_packet_id=?,completion_evidence_json=?,claimed_by=NULL,lease_expires_at=NULL,verification_claimed_by=NULL,verification_lease_expires_at=NULL,updated_at=? WHERE task_id=? AND claimed_by=? AND status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at>?",(producer_worker_id,packet_id,evidence_json,now_s,task_id,producer_worker_id,now_s))
+            # The current live execution lease is the authority to submit this attempt.
+            # `produced_by` is therefore attempt-local current state, while the append-only
+            # producer_completion_submitted events retain provenance for prior attempts.
+            cursor=self.conn.execute("UPDATE tasks SET status='verifying',produced_by=?,completion_packet_id=?,completion_evidence_json=?,claimed_by=NULL,lease_expires_at=NULL,verification_claimed_by=NULL,verification_lease_expires_at=NULL,updated_at=? WHERE task_id=? AND claimed_by=? AND status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at>?",(producer_worker_id,packet_id,evidence_json,now_s,task_id,producer_worker_id,now_s))
             if cursor.rowcount!=1: return False
             self._event(task_id,"producer_completion_submitted",producer_worker_id,{"packet_id":packet_id,"evidence_refs":list(evidence_refs)},now_s); return True
 

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -11,9 +11,10 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Mapping
+from typing import Iterable, Mapping
 
-from .verifier import VerificationDecision
+from .dispatcher import Worker
+from .verifier import select_verifier
 
 ACTIVE_LEASE_STATES = {"claimed", "running"}
 TERMINAL_STATES = {"completed", "rejected", "archived"}
@@ -44,8 +45,18 @@ class ClaimResult:
 class TaskLedger:
     """Small auditable SQLite ledger suitable for deterministic orchestration tests."""
 
-    def __init__(self, path: str | Path):
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        verification_workers: Iterable[Worker] = (),
+        independence_groups: Mapping[str, str] | None = None,
+    ):
         self.path = str(path)
+        self.verification_workers = {
+            worker.worker_id: worker for worker in verification_workers
+        }
+        self.independence_groups = dict(independence_groups or {})
         self.conn = sqlite3.connect(self.path, timeout=5.0)
         self.conn.row_factory = sqlite3.Row
         self.conn.execute("PRAGMA foreign_keys=ON")
@@ -128,20 +139,31 @@ class TaskLedger:
         verifier_worker_id: str,
         lease_seconds: int = 900,
         now: datetime | None = None,
-        *,
-        decision: VerificationDecision | None = None,
     ) -> ClaimResult:
         if lease_seconds<=0: raise ValueError("lease_seconds must be positive")
         now=now or _utcnow(); now_s=_iso(now); expires=_iso(now+timedelta(seconds=lease_seconds))
         with self.conn:
-            row=self.conn.execute("SELECT produced_by,verification_claimed_by,verification_lease_expires_at,status FROM tasks WHERE task_id=?",(task_id,)).fetchone()
+            row=self.conn.execute("SELECT payload_json,produced_by,completion_packet_id,attempt,verification_claimed_by,verification_lease_expires_at,status FROM tasks WHERE task_id=?",(task_id,)).fetchone()
             if not row: return ClaimResult(False,task_id,verifier_worker_id,"task_not_found")
             if row["status"]!="verifying": return ClaimResult(False,task_id,verifier_worker_id,"state_not_verifiable")
             if row["produced_by"]==verifier_worker_id: return ClaimResult(False,task_id,verifier_worker_id,"self_verification_forbidden")
-            if decision is None: return ClaimResult(False,task_id,verifier_worker_id,"verification_decision_required")
-            if decision.state != "verification_claim": return ClaimResult(False,task_id,verifier_worker_id,"verifier_not_independent")
-            if decision.worker_id != verifier_worker_id: return ClaimResult(False,task_id,verifier_worker_id,"verification_decision_mismatch")
-            if decision.producer_worker_id != row["produced_by"]: return ClaimResult(False,task_id,verifier_worker_id,"verification_decision_mismatch")
+            candidate = self.verification_workers.get(verifier_worker_id)
+            producer_group = self.independence_groups.get(row["produced_by"])
+            if candidate is None or producer_group is None:
+                return ClaimResult(False,task_id,verifier_worker_id,"verification_registry_missing")
+            task = json.loads(row["payload_json"])
+            required_capabilities = frozenset(task.get("required_capabilities", [])) | {"verification"}
+            risk_class = str(task.get("risk_class", "repo_write"))
+            decision = select_verifier(
+                producer_worker_id=row["produced_by"],
+                producer_independence_group=producer_group,
+                workers=self.verification_workers.values(),
+                independence_groups=self.independence_groups,
+                required_capabilities=frozenset(required_capabilities),
+                risk_class=risk_class,
+            )
+            if decision.state != "verification_claim" or decision.worker_id != verifier_worker_id:
+                return ClaimResult(False,task_id,verifier_worker_id,"verifier_not_independent")
             owner=row["verification_claimed_by"]; expiry=_parse(row["verification_lease_expires_at"])
             if owner==verifier_worker_id and expiry and expiry>now:
                 self.conn.execute("UPDATE tasks SET verification_lease_expires_at=?,updated_at=? WHERE task_id=?",(expires,now_s,task_id)); self._event(task_id,"verification_lease_renewed",verifier_worker_id,{"expires":expires},now_s); return ClaimResult(True,task_id,verifier_worker_id,"renewed",expires)

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -19,6 +19,14 @@ from .verifier import select_verifier
 ACTIVE_LEASE_STATES = {"claimed", "running"}
 TERMINAL_STATES = {"completed", "rejected", "archived"}
 NON_DISPATCHABLE_STATES = ACTIVE_LEASE_STATES | {"verifying", "review", "blocked", "human_review"} | TERMINAL_STATES
+DEFAULT_MAX_ATTEMPTS = 3
+SYSTEM_MAX_REJECTIONS = 2
+
+
+def _positive_limit(value: object) -> int:
+    if type(value) is not int or value <= 0:
+        raise ValueError("retry limits must be positive integers")
+    return value
 
 
 def _utcnow() -> datetime:
@@ -86,21 +94,39 @@ class TaskLedger:
         for name, definition in (("produced_by","TEXT"),("completion_packet_id","TEXT"),("completion_evidence_json","TEXT"),("verification_claimed_by","TEXT"),("verification_lease_expires_at","TEXT"),("verification_rejections","INTEGER NOT NULL DEFAULT 0")):
             if name not in existing:
                 self.conn.execute(f"ALTER TABLE tasks ADD COLUMN {name} {definition}")
+        for name in ("execution_max_attempts", "verification_max_rejections"):
+            if name not in existing:
+                self.conn.execute(f"ALTER TABLE tasks ADD COLUMN {name} INTEGER")
+        # Snapshot legacy task policy once. Invalid legacy policy receives a zero
+        # budget, routing acquisition to human review without deleting history.
+        for row in self.conn.execute("SELECT task_id,payload_json FROM tasks WHERE execution_max_attempts IS NULL").fetchall():
+            try:
+                limit = _positive_limit(json.loads(row["payload_json"]).get("max_attempts", DEFAULT_MAX_ATTEMPTS))
+            except (ValueError, TypeError, AttributeError):
+                limit = 0
+            self.conn.execute("UPDATE tasks SET execution_max_attempts=? WHERE task_id=?", (limit, row["task_id"]))
+        self.conn.execute("UPDATE tasks SET verification_max_rejections=? WHERE verification_max_rejections IS NULL", (SYSTEM_MAX_REJECTIONS,))
         self.conn.commit()
 
     def put_task(self, task: Mapping) -> None:
+        limit = _positive_limit(task.get("max_attempts", DEFAULT_MAX_ATTEMPTS))
+        attempt = task.get("attempt", 0)
+        if type(attempt) is not int or attempt < 0:
+            raise ValueError("attempt must be a nonnegative integer")
         task_id=str(task["task_id"]); status=str(task.get("status","queued")); now=_iso(_utcnow()); payload=json.dumps(dict(task),sort_keys=True)
         with self.conn:
-            self.conn.execute("""INSERT INTO tasks(task_id,payload_json,status,attempt,updated_at) VALUES(?,?,?,?,?)
-            ON CONFLICT(task_id) DO UPDATE SET payload_json=excluded.payload_json,
-            status=CASE WHEN tasks.status IN ('claimed','running','verifying','review','blocked','human_review','completed','rejected','archived') THEN tasks.status ELSE excluded.status END,
-            updated_at=excluded.updated_at""",(task_id,payload,status,int(task.get("attempt",0)),now))
-            self._event(task_id,"task_upserted","ledger",{"status":status},now)
+            self.conn.execute("""INSERT INTO tasks(task_id,payload_json,status,attempt,updated_at,execution_max_attempts,verification_max_rejections) VALUES(?,?,?,?,?,?,?)
+            ON CONFLICT(task_id) DO UPDATE SET
+            updated_at=excluded.updated_at""",(task_id,payload,status,attempt,now,limit,SYSTEM_MAX_REJECTIONS))
+            actual_status = self.conn.execute("SELECT status FROM tasks WHERE task_id=?", (task_id,)).fetchone()["status"]
+            self._event(task_id,"task_upserted","ledger",{"status":actual_status,"requested_status":status},now)
 
     def get(self, task_id: str) -> dict | None:
         row=self.conn.execute("SELECT * FROM tasks WHERE task_id=?",(task_id,)).fetchone()
         if not row: return None
         result=json.loads(row["payload_json"])
+        result["max_attempts"] = row["execution_max_attempts"]
+        result["max_verification_rejections"] = row["verification_max_rejections"]
         result.update({"status":row["status"],"attempt":row["attempt"],"claimed_by":row["claimed_by"],"lease_expires_at":row["lease_expires_at"],"produced_by":row["produced_by"],"completion_packet_id":row["completion_packet_id"],"completion_evidence":json.loads(row["completion_evidence_json"] or "[]"),"verification_claimed_by":row["verification_claimed_by"],"verification_lease_expires_at":row["verification_lease_expires_at"],"verification_rejections":row["verification_rejections"]})
         return result
 
@@ -108,9 +134,16 @@ class TaskLedger:
         if lease_seconds<=0: raise ValueError("lease_seconds must be positive")
         now=now or _utcnow(); now_s=_iso(now); expires=_iso(now+timedelta(seconds=lease_seconds))
         with self.conn:
+            self.conn.execute("BEGIN IMMEDIATE")
             renewed=self.conn.execute("UPDATE tasks SET status='claimed',lease_expires_at=?,updated_at=? WHERE task_id=? AND claimed_by=? AND lease_expires_at IS NOT NULL AND lease_expires_at>? AND status IN ('claimed','running')",(expires,now_s,task_id,worker_id,now_s))
             if renewed.rowcount==1:
                 self._event(task_id,"lease_renewed",worker_id,{"expires":expires},now_s); return ClaimResult(True,task_id,worker_id,"renewed",expires)
+            exhausted = self.conn.execute("""UPDATE tasks SET status='human_review',claimed_by=NULL,lease_expires_at=NULL,updated_at=?
+                WHERE task_id=? AND (attempt>=execution_max_attempts OR verification_rejections>=verification_max_rejections)
+                AND (status='queued' OR (status IN ('claimed','running') AND lease_expires_at<=?))""", (now_s, task_id, now_s))
+            if exhausted.rowcount == 1:
+                self._event(task_id, "retry_budget_exhausted", worker_id, {"status": "human_review"}, now_s)
+                return ClaimResult(False, task_id, worker_id, "attempt_limit_reached")
             acquired=self.conn.execute("UPDATE tasks SET status='claimed',attempt=attempt+1,claimed_by=?,lease_expires_at=?,updated_at=? WHERE task_id=? AND ((status='queued' AND (claimed_by IS NULL OR lease_expires_at IS NULL OR lease_expires_at<=?)) OR (status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at<=?))",(worker_id,expires,now_s,task_id,now_s,now_s))
             if acquired.rowcount==1:
                 self._event(task_id,"task_claimed",worker_id,{"expires":expires},now_s); return ClaimResult(True,task_id,worker_id,"claimed",expires)
@@ -123,15 +156,21 @@ class TaskLedger:
             if row["status"]!="queued": return ClaimResult(False,task_id,worker_id,"state_not_claimable",row["lease_expires_at"])
             return ClaimResult(False,task_id,worker_id,"active_lease",row["lease_expires_at"])
 
-    def submit_for_verification(self, task_id: str, producer_worker_id: str, packet_id: str, evidence_refs: list[str], now: datetime|None=None) -> bool:
+    def submit_for_verification(self, task_id: str, producer_worker_id: str, packet_id: str, evidence_refs: list[str], now: datetime|None=None, *, completion_checks: list[dict]|None=None) -> bool:
+        if not isinstance(packet_id, str) or not packet_id.strip():
+            return False
+        if not isinstance(evidence_refs, list) or any(not isinstance(ref, str) or not ref.strip() for ref in evidence_refs):
+            return False
         now=now or _utcnow(); now_s=_iso(now); evidence_json=json.dumps(list(evidence_refs),sort_keys=True)
         with self.conn:
+            self.conn.execute("BEGIN IMMEDIATE")
+            lease = self.conn.execute("SELECT attempt,lease_expires_at FROM tasks WHERE task_id=?", (task_id,)).fetchone()
             # The current live execution lease is the authority to submit this attempt.
             # `produced_by` is therefore attempt-local current state, while the append-only
             # producer_completion_submitted events retain provenance for prior attempts.
             cursor=self.conn.execute("UPDATE tasks SET status='verifying',produced_by=?,completion_packet_id=?,completion_evidence_json=?,claimed_by=NULL,lease_expires_at=NULL,verification_claimed_by=NULL,verification_lease_expires_at=NULL,updated_at=? WHERE task_id=? AND claimed_by=? AND status IN ('claimed','running') AND lease_expires_at IS NOT NULL AND lease_expires_at>?",(producer_worker_id,packet_id,evidence_json,now_s,task_id,producer_worker_id,now_s))
             if cursor.rowcount!=1: return False
-            self._event(task_id,"producer_completion_submitted",producer_worker_id,{"packet_id":packet_id,"evidence_refs":list(evidence_refs)},now_s); return True
+            self._event(task_id,"producer_completion_submitted",producer_worker_id,{"packet_id":packet_id,"evidence_refs":list(evidence_refs),"attempt":lease["attempt"],"producer_lease_expires_at":lease["lease_expires_at"],"checks":completion_checks or []},now_s); return True
 
     def claim_verification(
         self,
@@ -178,14 +217,17 @@ class TaskLedger:
             self._event(task_id,"verification_accepted",verifier_worker_id,{"evidence_refs":list(evidence_refs)},now_s); return True
 
     def reject_verification(self, task_id: str, verifier_worker_id: str, reason: str, evidence_refs: list[str], max_rejections: int=2, now: datetime|None=None) -> bool:
-        if max_rejections<=0: raise ValueError("max_rejections must be positive")
+        # Retained only for source compatibility. Callers cannot set policy.
+        # The persisted system ceiling is authoritative even for 0/9999/None.
         now=now or _utcnow(); now_s=_iso(now)
         with self.conn:
-            row=self.conn.execute("SELECT verification_rejections FROM tasks WHERE task_id=? AND status='verifying' AND verification_claimed_by=? AND verification_lease_expires_at IS NOT NULL AND verification_lease_expires_at>?",(task_id,verifier_worker_id,now_s)).fetchone()
+            self.conn.execute("BEGIN IMMEDIATE")
+            row=self.conn.execute("SELECT * FROM tasks WHERE task_id=? AND status='verifying' AND verification_claimed_by=? AND verification_lease_expires_at IS NOT NULL AND verification_lease_expires_at>?",(task_id,verifier_worker_id,now_s)).fetchone()
             if not row: return False
-            count=int(row["verification_rejections"])+1; next_status="human_review" if count>=max_rejections else "queued"
+            count=int(row["verification_rejections"])+1
+            next_status = "human_review" if count >= row["verification_max_rejections"] or row["attempt"] >= row["execution_max_attempts"] else "queued"
             self.conn.execute("UPDATE tasks SET status=?,verification_rejections=?,verification_claimed_by=NULL,verification_lease_expires_at=NULL,claimed_by=NULL,lease_expires_at=NULL,updated_at=? WHERE task_id=?",(next_status,count,now_s,task_id))
-            self._event(task_id,"verification_rejected",verifier_worker_id,{"reason":reason,"evidence_refs":list(evidence_refs),"rejections":count,"next_status":next_status},now_s); return True
+            self._event(task_id,"verification_rejected",verifier_worker_id,{"reason":reason,"evidence_refs":list(evidence_refs),"rejections":count,"next_status":next_status,"max_rejections":row["verification_max_rejections"],"attempt":row["attempt"]},now_s); return True
 
     def reap_expired_verification(self, now: datetime|None=None) -> list[str]:
         now=now or _utcnow(); now_s=_iso(now)
@@ -200,9 +242,30 @@ class TaskLedger:
 
     def release(self, task_id: str, worker_id: str, next_status: str="queued", now: datetime|None=None) -> bool:
         if next_status in ACTIVE_LEASE_STATES: raise ValueError("release next_status cannot retain an active lease state")
+        if next_status not in {"queued", "review", "blocked", "human_review", "rejected", "completed"}:
+            return False
         now_s=_iso(now or _utcnow())
         with self.conn:
-            cursor=self.conn.execute("UPDATE tasks SET status=?,claimed_by=NULL,lease_expires_at=NULL,updated_at=? WHERE task_id=? AND claimed_by=?",(next_status,now_s,task_id,worker_id))
+            # Serialize policy inspection and mutation with other ledger writers.
+            self.conn.execute("BEGIN IMMEDIATE")
+            row = self.conn.execute("SELECT * FROM tasks WHERE task_id=?", (task_id,)).fetchone()
+            if row is None:
+                return False
+            task = json.loads(row["payload_json"])
+            if next_status == "completed" and (
+                task.get("risk_class") != "read_only"
+                or task.get("human_approval_required", False)
+                or task.get("required_review_roles")
+                or task.get("required_checks")
+                or "verification" in task.get("required_capabilities", [])
+            ):
+                return False
+            if next_status == "queued" and (
+                row["attempt"] >= row["execution_max_attempts"]
+                or row["verification_rejections"] >= row["verification_max_rejections"]
+            ):
+                next_status = "human_review"
+            cursor=self.conn.execute("UPDATE tasks SET status=?,claimed_by=NULL,lease_expires_at=NULL,updated_at=? WHERE task_id=? AND claimed_by=? AND status IN ('claimed','running') AND lease_expires_at>?",(next_status,now_s,task_id,worker_id,now_s))
             if cursor.rowcount!=1: return False
             self._event(task_id,"task_released",worker_id,{"status":next_status},now_s); return True
 
@@ -212,8 +275,11 @@ class TaskLedger:
         with self.conn:
             reaped=[]
             for row in expired:
-                cursor=self.conn.execute("UPDATE tasks SET status='queued',claimed_by=NULL,lease_expires_at=NULL,updated_at=? WHERE task_id=? AND claimed_by=? AND lease_expires_at=? AND status IN ('claimed','running')",(now_s,row["task_id"],row["claimed_by"],row["lease_expires_at"]))
-                if cursor.rowcount==1: self._event(row["task_id"],"lease_expired",row["claimed_by"],{},now_s); reaped.append(row["task_id"])
+                cursor=self.conn.execute("UPDATE tasks SET status=CASE WHEN attempt>=execution_max_attempts OR verification_rejections>=verification_max_rejections THEN 'human_review' ELSE 'queued' END,claimed_by=NULL,lease_expires_at=NULL,updated_at=? WHERE task_id=? AND claimed_by=? AND lease_expires_at=? AND status IN ('claimed','running')",(now_s,row["task_id"],row["claimed_by"],row["lease_expires_at"]))
+                if cursor.rowcount==1:
+                    status = self.conn.execute("SELECT status FROM tasks WHERE task_id=?", (row["task_id"],)).fetchone()["status"]
+                    self._event(row["task_id"],"lease_expired",row["claimed_by"],{"status":status},now_s)
+                    reaped.append(row["task_id"])
         return reaped
 
     def events(self, task_id: str) -> list[dict]:

--- a/elysia_collective_seed/autopilot/task_ledger.py
+++ b/elysia_collective_seed/autopilot/task_ledger.py
@@ -13,6 +13,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Mapping
 
+from .verifier import VerificationDecision
+
 ACTIVE_LEASE_STATES = {"claimed", "running"}
 TERMINAL_STATES = {"completed", "rejected", "archived"}
 NON_DISPATCHABLE_STATES = ACTIVE_LEASE_STATES | {"verifying", "review", "blocked", "human_review"} | TERMINAL_STATES
@@ -104,6 +106,9 @@ class TaskLedger:
             row=self.conn.execute("SELECT * FROM tasks WHERE task_id=?",(task_id,)).fetchone()
             if not row: return ClaimResult(False,task_id,worker_id,"task_not_found")
             if row["status"] in TERMINAL_STATES: return ClaimResult(False,task_id,worker_id,"terminal_task")
+            lease_expiry = _parse(row["lease_expires_at"])
+            if row["status"] in ACTIVE_LEASE_STATES and lease_expiry and lease_expiry > now:
+                return ClaimResult(False,task_id,worker_id,"active_lease",row["lease_expires_at"])
             if row["status"]!="queued": return ClaimResult(False,task_id,worker_id,"state_not_claimable",row["lease_expires_at"])
             return ClaimResult(False,task_id,worker_id,"active_lease",row["lease_expires_at"])
 
@@ -117,7 +122,15 @@ class TaskLedger:
             if cursor.rowcount!=1: return False
             self._event(task_id,"producer_completion_submitted",producer_worker_id,{"packet_id":packet_id,"evidence_refs":list(evidence_refs)},now_s); return True
 
-    def claim_verification(self, task_id: str, verifier_worker_id: str, lease_seconds: int=900, now: datetime|None=None) -> ClaimResult:
+    def claim_verification(
+        self,
+        task_id: str,
+        verifier_worker_id: str,
+        lease_seconds: int = 900,
+        now: datetime | None = None,
+        *,
+        decision: VerificationDecision | None = None,
+    ) -> ClaimResult:
         if lease_seconds<=0: raise ValueError("lease_seconds must be positive")
         now=now or _utcnow(); now_s=_iso(now); expires=_iso(now+timedelta(seconds=lease_seconds))
         with self.conn:
@@ -125,6 +138,10 @@ class TaskLedger:
             if not row: return ClaimResult(False,task_id,verifier_worker_id,"task_not_found")
             if row["status"]!="verifying": return ClaimResult(False,task_id,verifier_worker_id,"state_not_verifiable")
             if row["produced_by"]==verifier_worker_id: return ClaimResult(False,task_id,verifier_worker_id,"self_verification_forbidden")
+            if decision is None: return ClaimResult(False,task_id,verifier_worker_id,"verification_decision_required")
+            if decision.state != "verification_claim": return ClaimResult(False,task_id,verifier_worker_id,"verifier_not_independent")
+            if decision.worker_id != verifier_worker_id: return ClaimResult(False,task_id,verifier_worker_id,"verification_decision_mismatch")
+            if decision.producer_worker_id != row["produced_by"]: return ClaimResult(False,task_id,verifier_worker_id,"verification_decision_mismatch")
             owner=row["verification_claimed_by"]; expiry=_parse(row["verification_lease_expires_at"])
             if owner==verifier_worker_id and expiry and expiry>now:
                 self.conn.execute("UPDATE tasks SET verification_lease_expires_at=?,updated_at=? WHERE task_id=?",(expires,now_s,task_id)); self._event(task_id,"verification_lease_renewed",verifier_worker_id,{"expires":expires},now_s); return ClaimResult(True,task_id,verifier_worker_id,"renewed",expires)

--- a/elysia_collective_seed/autopilot/test_dryrun_orchestrator.py
+++ b/elysia_collective_seed/autopilot/test_dryrun_orchestrator.py
@@ -98,12 +98,18 @@ def test_existing_active_lease_is_not_stolen(tmp_path: Path):
 
 
 def test_stale_payload_cannot_reopen_completed_task(tmp_path: Path):
-    ledger = TaskLedger(tmp_path / "ledger.db")
+    ledger = TaskLedger(
+        tmp_path / "ledger.db",
+        verification_workers=[Worker("verifier", "dryrun", frozenset({"verification"}), frozenset({"sandbox_write"}))],
+        independence_groups={"worker-a": "producer", "verifier": "independent"},
+    )
     try:
         task = _task()
         ledger.put_task(task)
         assert ledger.claim(task["task_id"], "worker-a", lease_seconds=60).claimed
-        assert ledger.release(task["task_id"], "worker-a", next_status="completed")
+        assert ledger.submit_for_verification(task["task_id"], "worker-a", "packet:test", ["test:evidence"])
+        assert ledger.claim_verification(task["task_id"], "verifier").claimed
+        assert ledger.accept_verification(task["task_id"], "verifier", ["test:review"])
         result = dispatch_and_claim(ledger, task, {}, _workers())
         assert result.state == "not_dispatchable"
         assert result.reasons == ("terminal_task",)

--- a/elysia_collective_seed/autopilot/verifier.py
+++ b/elysia_collective_seed/autopilot/verifier.py
@@ -1,0 +1,55 @@
+"""Deterministic, runtime-disabled verifier routing primitives.
+
+This module never executes work or grants authority. It only determines whether
+an independent verifier may claim review of producer evidence.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .dispatcher import Worker
+
+
+@dataclass(frozen=True)
+class VerificationDecision:
+    state: str
+    worker_id: str | None
+    reasons: tuple[str, ...]
+
+
+def select_verifier(
+    *,
+    producer_worker_id: str,
+    producer_independence_group: str,
+    workers: Iterable[Worker],
+    independence_groups: dict[str, str],
+    required_capabilities: frozenset[str] = frozenset({"verification"}),
+    risk_class: str = "repo_write",
+) -> VerificationDecision:
+    """Select an eligible verifier that is independent of the producer.
+
+    Fail closed when no independent verifier exists. The producer is excluded
+    even if group metadata is absent or malformed.
+    """
+    eligible: list[Worker] = []
+    for worker in workers:
+        if not worker.available or worker.worker_id == producer_worker_id:
+            continue
+        if risk_class not in worker.risk_classes:
+            continue
+        if not required_capabilities.issubset(worker.capabilities):
+            continue
+        group = independence_groups.get(worker.worker_id)
+        if not group or group == producer_independence_group:
+            continue
+        eligible.append(worker)
+
+    if not eligible:
+        return VerificationDecision("blocked", None, ("no_independent_verifier",))
+
+    chosen = max(
+        eligible,
+        key=lambda worker: (worker.quality - 0.25 * worker.cost, worker.worker_id),
+    )
+    return VerificationDecision("verification_claim", chosen.worker_id, ("independent_verifier",))

--- a/elysia_collective_seed/autopilot/verifier.py
+++ b/elysia_collective_seed/autopilot/verifier.py
@@ -33,6 +33,12 @@ def select_verifier(
     Fail closed when no independent verifier exists. The producer is excluded
     even if group metadata is absent or malformed.
     """
+    registered_producer_group = independence_groups.get(producer_worker_id)
+    if not registered_producer_group or registered_producer_group != producer_independence_group:
+        return VerificationDecision(
+            "blocked", None, producer_worker_id, ("producer_independence_metadata_invalid",)
+        )
+
     eligible: list[Worker] = []
     for worker in workers:
         if not worker.available or worker.worker_id == producer_worker_id:

--- a/elysia_collective_seed/autopilot/verifier.py
+++ b/elysia_collective_seed/autopilot/verifier.py
@@ -15,6 +15,7 @@ from .dispatcher import Worker
 class VerificationDecision:
     state: str
     worker_id: str | None
+    producer_worker_id: str
     reasons: tuple[str, ...]
 
 
@@ -46,10 +47,17 @@ def select_verifier(
         eligible.append(worker)
 
     if not eligible:
-        return VerificationDecision("blocked", None, ("no_independent_verifier",))
+        return VerificationDecision(
+            "blocked", None, producer_worker_id, ("no_independent_verifier",)
+        )
 
     chosen = max(
         eligible,
         key=lambda worker: (worker.quality - 0.25 * worker.cost, worker.worker_id),
     )
-    return VerificationDecision("verification_claim", chosen.worker_id, ("independent_verifier",))
+    return VerificationDecision(
+        "verification_claim",
+        chosen.worker_id,
+        producer_worker_id,
+        ("independent_verifier",),
+    )

--- a/tests/test_autopilot_lifecycle_repairs.py
+++ b/tests/test_autopilot_lifecycle_repairs.py
@@ -1,0 +1,224 @@
+"""Regression tests for issues #19, #20 and #21; local SQLite only."""
+from datetime import timedelta
+
+import pytest
+
+from tests.test_vega_verifier_boundaries import NOW, open_ledger, task
+from elysia_collective_seed.autopilot.dryrun_orchestrator import validate_and_apply_completion
+
+
+@pytest.mark.parametrize("risk", ["repo_write", "sandbox_write", "deployment", None])
+def test_release_cannot_complete_write_or_unknown_risk(tmp_path, risk):
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        ledger.put_task(task(risk_class=risk))
+        assert ledger.claim("vega", "writer", now=NOW).claimed
+        assert not ledger.release("vega", "writer", "completed", now=NOW)
+        assert ledger.get("vega")["status"] == "claimed"
+        assert not any(e["event_type"] == "verification_accepted" for e in ledger.events("vega"))
+    finally:
+        ledger.close()
+
+
+def test_read_only_release_requires_live_lease_and_no_review_gate(tmp_path):
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        ledger.put_task(task(risk_class="read_only", required_capabilities=[]))
+        assert ledger.claim("vega", "writer", lease_seconds=10, now=NOW).claimed
+        assert not ledger.release("vega", "writer", "completed", now=NOW + timedelta(seconds=10))
+        assert ledger.release("vega", "writer", "completed", now=NOW + timedelta(seconds=1))
+    finally:
+        ledger.close()
+
+
+def test_upsert_cannot_downgrade_write_or_mark_queued_task_complete(tmp_path):
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        ledger.put_task(task())
+        ledger.put_task(task(risk_class="read_only", required_capabilities=[], status="completed"))
+        assert ledger.get("vega")["status"] == "queued"
+        assert ledger.get("vega")["risk_class"] == "repo_write"
+        assert ledger.claim("vega", "writer", now=NOW).claimed
+        assert not ledger.release("vega", "writer", "completed", now=NOW)
+    finally:
+        ledger.close()
+
+
+@pytest.mark.parametrize("limit", [0, -1, True, 1.5, "3", None])
+def test_invalid_execution_policy_rejected_at_admission(tmp_path, limit):
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        with pytest.raises(ValueError):
+            ledger.put_task(task(max_attempts=limit))
+        assert ledger.get("vega") is None
+    finally:
+        ledger.close()
+
+
+def test_policy_cannot_be_raised_by_upsert_after_reopen(tmp_path):
+    path = tmp_path / "ledger.db"
+    ledger = open_ledger(path)
+    ledger.put_task(task())
+    assert ledger.claim("vega", "writer", now=NOW).claimed
+    assert ledger.release("vega", "writer", now=NOW)
+    ledger.close()
+    ledger = open_ledger(path)
+    try:
+        ledger.put_task(task(max_attempts=9999, attempt=0))
+        assert ledger.get("vega")["max_attempts"] == 1
+        assert ledger.get("vega")["status"] == "human_review"
+        assert not ledger.claim("vega", "writer", now=NOW).claimed
+        assert ledger.get("vega")["attempt"] == 1
+    finally:
+        ledger.close()
+
+
+def test_concurrent_expired_reclaims_cannot_exceed_budget(tmp_path):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    path = tmp_path / "ledger.db"
+    ledger = open_ledger(path)
+    ledger.put_task(task())
+    assert ledger.claim("vega", "writer", lease_seconds=1, now=NOW).claimed
+    ledger.close()
+    barrier = Barrier(2)
+
+    def reclaim(worker):
+        other = open_ledger(path)
+        try:
+            barrier.wait(timeout=5)
+            return other.claim("vega", worker, now=NOW + timedelta(seconds=2)).claimed
+        finally:
+            other.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        assert list(pool.map(reclaim, ("worker-a", "worker-b"))) == [False, False]
+    ledger = open_ledger(path)
+    try:
+        assert ledger.get("vega")["attempt"] == 1
+        assert ledger.get("vega")["status"] == "human_review"
+        assert sum(e["event_type"] == "retry_budget_exhausted" for e in ledger.events("vega")) == 1
+    finally:
+        ledger.close()
+
+
+@pytest.mark.parametrize("caller_limit", [0, 1, 9999, None])
+def test_rejection_uses_system_policy_regardless_of_caller(tmp_path, caller_limit):
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        ledger.put_task(task(max_attempts=3))
+        for index in range(2):
+            assert ledger.claim("vega", "writer", now=NOW).claimed
+            assert ledger.submit_for_verification("vega", "writer", str(index), [], now=NOW)
+            assert ledger.claim_verification("vega", "reviewer", now=NOW).claimed
+            assert ledger.reject_verification("vega", "reviewer", "failure", [], max_rejections=caller_limit, now=NOW)
+            assert ledger.get("vega")["status"] == ("queued" if index == 0 else "human_review")
+        assert ledger.get("vega")["attempt"] == 2
+    finally:
+        ledger.close()
+
+
+def completion(**overrides):
+    packet = dict(task_id="vega", worker={"provider": "synthetic", "role": "engineer"},
+                  summary="Synthetic result", outcome="completed",
+                  checks=[{"name": "unit", "result": "pass"}],
+                  next_recommendation={"action": "verify"})
+    packet.update(overrides)
+    return packet
+
+
+def test_bridge_persists_identity_evidence_and_lease_provenance_across_reopen(tmp_path):
+    path = tmp_path / "ledger.db"
+    ledger = open_ledger(path)
+    ledger.put_task(task(required_checks=["unit"]))
+    assert ledger.claim("vega", "writer").claimed
+    lease = ledger.get("vega")["lease_expires_at"]
+    packet = completion(packet_id="packet-explicit", evidence_refs=["ref:direct"],
+                        claims=[{"claim": "tested", "evidence": ["ref:claim"]}])
+    assert validate_and_apply_completion(ledger, packet, worker_id="writer").applied
+    ledger.close()
+    ledger = open_ledger(path)
+    try:
+        row = ledger.get("vega")
+        assert row["produced_by"] == "writer"
+        assert row["completion_packet_id"] == "packet-explicit"
+        assert {"ref:direct", "ref:claim"}.issubset(row["completion_evidence"])
+        event = ledger.events("vega")[-1]
+        assert event["detail"]["checks"] == [{"name": "unit", "result": "pass"}]
+        assert event["detail"]["attempt"] == 1
+        assert event["detail"]["producer_lease_expires_at"] == lease
+        assert ledger.claim_verification("vega", "reviewer").claimed
+        assert ledger.accept_verification("vega", "reviewer", ["ref:review"])
+    finally:
+        ledger.close()
+
+
+def test_legacy_packet_gets_stable_content_identity(tmp_path):
+    import hashlib
+    import json
+
+    packet = completion()
+    expected = "sha256:" + hashlib.sha256(json.dumps(packet, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()).hexdigest()
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        ledger.put_task(task())
+        assert ledger.claim("vega", "writer").claimed
+        assert validate_and_apply_completion(ledger, packet, worker_id="writer").applied
+        assert ledger.get("vega")["completion_packet_id"] == expected
+        assert expected in ledger.get("vega")["completion_evidence"]
+    finally:
+        ledger.close()
+
+
+@pytest.mark.parametrize("changes", [{"packet_id": ""}, {"evidence_refs": "bad"},
+                                     {"claims": [{"claim": "missing evidence"}]}, {"checks": []}])
+def test_bridge_rejects_malformed_evidence_and_cannot_omit_task_checks(tmp_path, changes):
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        ledger.put_task(task(required_checks=["unit"]))
+        assert ledger.claim("vega", "writer").claimed
+        before = ledger.events("vega")
+        assert not validate_and_apply_completion(ledger, completion(**changes), worker_id="writer").applied
+        assert ledger.get("vega")["status"] == "claimed"
+        assert ledger.events("vega") == before
+    finally:
+        ledger.close()
+
+
+def test_bridge_refuses_expired_producer_lease(tmp_path, monkeypatch):
+    import elysia_collective_seed.autopilot.task_ledger as ledger_module
+
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        ledger.put_task(task())
+        assert ledger.claim("vega", "writer", lease_seconds=1, now=NOW).claimed
+        monkeypatch.setattr(ledger_module, "_utcnow", lambda: NOW + timedelta(seconds=1))
+        before = ledger.events("vega")
+        assert not validate_and_apply_completion(ledger, completion(), worker_id="writer").applied
+        assert ledger.get("vega")["produced_by"] is None
+        assert ledger.events("vega") == before
+    finally:
+        ledger.close()
+
+
+def test_legacy_policy_migration_is_durable_and_preserves_events(tmp_path):
+    from tests.test_autopilot_verifier_ledger_migration import _legacy_ledger
+
+    path = tmp_path / "legacy.db"
+    _legacy_ledger(path)
+    ledger = open_ledger(path)
+    try:
+        assert ledger.get("legacy-task")["max_attempts"] == 3
+        assert ledger.claim("legacy-task", "writer", now=NOW).claimed
+        assert ledger.release("legacy-task", "writer", now=NOW)
+    finally:
+        ledger.close()
+    ledger = open_ledger(path)
+    try:
+        assert ledger.get("legacy-task")["status"] == "human_review"
+        assert ledger.get("legacy-task")["attempt"] == 3
+        assert ledger.events("legacy-task")[0]["detail"] == {"proof": "keep"}
+        assert not ledger.claim("legacy-task", "writer", now=NOW).claimed
+    finally:
+        ledger.close()

--- a/tests/test_autopilot_verifier.py
+++ b/tests/test_autopilot_verifier.py
@@ -1,0 +1,65 @@
+from elysia_collective_seed.autopilot.dispatcher import Worker
+from elysia_collective_seed.autopilot.verifier import select_verifier
+
+
+def worker(worker_id: str, group: str, *, quality: float = 0.5) -> tuple[Worker, str]:
+    return (
+        Worker(
+            worker_id=worker_id,
+            provider="test",
+            capabilities=frozenset({"verification"}),
+            risk_classes=frozenset({"repo_write"}),
+            quality=quality,
+        ),
+        group,
+    )
+
+
+def test_producer_cannot_verify_own_write():
+    producer, group = worker("producer", "group-a")
+    decision = select_verifier(
+        producer_worker_id="producer",
+        producer_independence_group=group,
+        workers=[producer],
+        independence_groups={"producer": group},
+    )
+    assert decision.state == "blocked"
+    assert decision.worker_id is None
+    assert decision.reasons == ("no_independent_verifier",)
+
+
+def test_same_independence_group_is_rejected():
+    producer, group = worker("producer", "group-a")
+    peer, _ = worker("peer", "group-a")
+    decision = select_verifier(
+        producer_worker_id="producer",
+        producer_independence_group=group,
+        workers=[producer, peer],
+        independence_groups={"producer": group, "peer": group},
+    )
+    assert decision.state == "blocked"
+
+
+def test_distinct_group_can_claim_verification():
+    producer, group = worker("producer", "group-a")
+    verifier, verifier_group = worker("verifier", "group-b", quality=0.9)
+    decision = select_verifier(
+        producer_worker_id="producer",
+        producer_independence_group=group,
+        workers=[producer, verifier],
+        independence_groups={"producer": group, "verifier": verifier_group},
+    )
+    assert decision.state == "verification_claim"
+    assert decision.worker_id == "verifier"
+
+
+def test_missing_group_metadata_fails_closed():
+    producer, group = worker("producer", "group-a")
+    verifier, _ = worker("verifier", "group-b")
+    decision = select_verifier(
+        producer_worker_id="producer",
+        producer_independence_group=group,
+        workers=[producer, verifier],
+        independence_groups={"producer": group},
+    )
+    assert decision.state == "blocked"

--- a/tests/test_autopilot_verifier.py
+++ b/tests/test_autopilot_verifier.py
@@ -63,3 +63,16 @@ def test_missing_group_metadata_fails_closed():
         independence_groups={"producer": group},
     )
     assert decision.state == "blocked"
+
+
+def test_spoofed_producer_group_fails_closed():
+    producer, _ = worker("producer", "real-group")
+    verifier, _ = worker("verifier", "real-group")
+    decision = select_verifier(
+        producer_worker_id="producer",
+        producer_independence_group="spoofed-group",
+        workers=[producer, verifier],
+        independence_groups={"producer": "real-group", "verifier": "real-group"},
+    )
+    assert decision.state == "blocked"
+    assert decision.reasons == ("producer_independence_metadata_invalid",)

--- a/tests/test_autopilot_verifier_ledger_migration.py
+++ b/tests/test_autopilot_verifier_ledger_migration.py
@@ -1,0 +1,101 @@
+"""Regression contract for additive AUTOPILOT-004 verifier-ledger migration.
+
+These tests intentionally define the required upgrade behavior before the schema
+migration is implemented. They use only a temporary local SQLite database.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from elysia_collective_seed.autopilot.task_ledger import TaskLedger
+
+
+VERIFIER_COLUMNS = {
+    "produced_by",
+    "completion_packet_id",
+    "completion_evidence_json",
+    "verification_claimed_by",
+    "verification_lease_expires_at",
+    "verification_rejections",
+}
+
+
+def _legacy_ledger(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+            task_id TEXT PRIMARY KEY,
+            payload_json TEXT NOT NULL,
+            status TEXT NOT NULL,
+            attempt INTEGER NOT NULL DEFAULT 0,
+            claimed_by TEXT,
+            lease_expires_at TEXT,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            actor TEXT,
+            detail_json TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(task_id) REFERENCES tasks(task_id)
+        );
+        INSERT INTO tasks VALUES (
+            'legacy-task', '{"task_id":"legacy-task","title":"preserve me"}',
+            'queued', 2, NULL, NULL, '2026-09-08T00:00:00+00:00'
+        );
+        INSERT INTO events(task_id,event_type,actor,detail_json,created_at)
+        VALUES ('legacy-task','legacy_event','legacy-worker','{"proof":"keep"}',
+                '2026-09-08T00:00:01+00:00');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_legacy_ledger_is_additively_migrated_without_history_loss(tmp_path: Path):
+    db = tmp_path / "legacy.sqlite3"
+    _legacy_ledger(db)
+
+    ledger = TaskLedger(db)
+    try:
+        columns = {
+            row["name"]
+            for row in ledger.conn.execute("PRAGMA table_info(tasks)").fetchall()
+        }
+        assert VERIFIER_COLUMNS.issubset(columns)
+
+        task = ledger.get("legacy-task")
+        assert task is not None
+        assert task["title"] == "preserve me"
+        assert task["attempt"] == 2
+        assert task["status"] == "queued"
+
+        events = ledger.events("legacy-task")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "legacy_event"
+        assert events[0]["detail"] == {"proof": "keep"}
+    finally:
+        ledger.close()
+
+
+def test_verifier_schema_initialization_is_idempotent(tmp_path: Path):
+    db = tmp_path / "idempotent.sqlite3"
+    _legacy_ledger(db)
+
+    first = TaskLedger(db)
+    first.close()
+    second = TaskLedger(db)
+    try:
+        columns = [
+            row["name"]
+            for row in second.conn.execute("PRAGMA table_info(tasks)").fetchall()
+        ]
+        for column in VERIFIER_COLUMNS:
+            assert columns.count(column) == 1
+        assert len(second.events("legacy-task")) == 1
+    finally:
+        second.close()

--- a/tests/test_autopilot_verifier_lifecycle.py
+++ b/tests/test_autopilot_verifier_lifecycle.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+from elysia_collective_seed.autopilot.dispatcher import Worker
 from elysia_collective_seed.autopilot.task_ledger import TaskLedger
+from elysia_collective_seed.autopilot.verifier import select_verifier
 
 NOW = datetime(2026, 9, 9, 12, 0, tzinfo=timezone.utc)
 
@@ -15,6 +17,40 @@ NOW = datetime(2026, 9, 9, 12, 0, tzinfo=timezone.utc)
 def _claimed_writer(ledger: TaskLedger, task_id: str = "write-1") -> None:
     ledger.put_task({"task_id": task_id, "status": "queued", "title": "bounded local write"})
     assert ledger.claim(task_id, "writer", now=NOW).claimed
+
+
+def _verification_decision(
+    verifier_worker_id: str,
+    *,
+    producer_worker_id: str = "writer",
+    producer_group: str = "producer-group",
+    verifier_group: str | None = "verifier-group",
+):
+    verifier = Worker(
+        worker_id=verifier_worker_id,
+        provider="test",
+        capabilities=frozenset({"verification"}),
+        risk_classes=frozenset({"repo_write"}),
+        quality=1.0,
+    )
+    groups = {producer_worker_id: producer_group}
+    if verifier_group is not None:
+        groups[verifier_worker_id] = verifier_group
+    return select_verifier(
+        producer_worker_id=producer_worker_id,
+        producer_independence_group=producer_group,
+        workers=[verifier],
+        independence_groups=groups,
+    )
+
+
+def _claim_verification(ledger: TaskLedger, verifier_worker_id: str, **kwargs):
+    return ledger.claim_verification(
+        "write-1",
+        verifier_worker_id,
+        decision=_verification_decision(verifier_worker_id),
+        **kwargs,
+    )
 
 
 def test_writer_submission_enters_verifying_and_releases_execution_lease(tmp_path):
@@ -38,11 +74,13 @@ def test_self_verification_forbidden_and_distinct_verifier_claims(tmp_path):
     try:
         _claimed_writer(ledger)
         ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
-        denied = ledger.claim_verification("write-1", "writer", now=NOW)
+        denied = ledger.claim_verification(
+            "write-1", "writer", decision=_verification_decision("writer"), now=NOW
+        )
         assert not denied.claimed and denied.reason == "self_verification_forbidden"
-        claimed = ledger.claim_verification("write-1", "verifier-a", now=NOW)
+        claimed = _claim_verification(ledger, "verifier-a", now=NOW)
         assert claimed.claimed
-        competing = ledger.claim_verification("write-1", "verifier-b", now=NOW)
+        competing = _claim_verification(ledger, "verifier-b", now=NOW)
         assert not competing.claimed
     finally:
         ledger.close()
@@ -53,11 +91,11 @@ def test_accept_requires_live_owner_and_records_decision(tmp_path):
     try:
         _claimed_writer(ledger)
         ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
-        ledger.claim_verification("write-1", "verifier-a", lease_seconds=60, now=NOW)
+        _claim_verification(ledger, "verifier-a", lease_seconds=60, now=NOW)
         assert not ledger.accept_verification("write-1", "verifier-b", ["review:wrong"], now=NOW)
         assert not ledger.accept_verification("write-1", "verifier-a", ["review:stale"], now=NOW + timedelta(seconds=61))
         assert ledger.reap_expired_verification(now=NOW + timedelta(seconds=61)) == ["write-1"]
-        assert ledger.claim_verification("write-1", "verifier-b", lease_seconds=60, now=NOW + timedelta(seconds=62)).claimed
+        assert _claim_verification(ledger, "verifier-b", lease_seconds=60, now=NOW + timedelta(seconds=62)).claimed
         assert ledger.accept_verification("write-1", "verifier-b", ["review:ok"], now=NOW + timedelta(seconds=63))
         row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
         assert row["status"] == "completed"
@@ -73,7 +111,7 @@ def test_rejection_preserves_evidence_and_attempt_and_bounds_retry(tmp_path):
         _claimed_writer(ledger)
         attempt = ledger.get("write-1")["attempt"]
         ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
-        ledger.claim_verification("write-1", "verifier-a", now=NOW)
+        _claim_verification(ledger, "verifier-a", now=NOW)
         assert ledger.reject_verification("write-1", "verifier-a", "test failure", ["review:fail"], max_rejections=2, now=NOW)
         row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
         assert row["status"] == "queued"
@@ -91,7 +129,7 @@ def test_rejected_retry_can_be_rerouted_without_losing_producer_provenance(tmp_p
     try:
         _claimed_writer(ledger)
         assert ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:first"], now=NOW)
-        assert ledger.claim_verification("write-1", "verifier-a", now=NOW).claimed
+        assert _claim_verification(ledger, "verifier-a", now=NOW).claimed
         assert ledger.reject_verification(
             "write-1", "verifier-a", "needs revision", ["review:first-fail"], max_rejections=3, now=NOW
         )
@@ -120,13 +158,43 @@ def test_expired_verifier_lease_reaps_without_touching_producer_evidence(tmp_pat
         _claimed_writer(ledger)
         attempt = ledger.get("write-1")["attempt"]
         ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
-        ledger.claim_verification("write-1", "verifier-a", lease_seconds=60, now=NOW)
+        _claim_verification(ledger, "verifier-a", lease_seconds=60, now=NOW)
         assert ledger.reap_expired_verification(now=NOW + timedelta(seconds=61)) == ["write-1"]
         row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
         assert row["status"] == "verifying"
         assert row["attempt"] == attempt
         assert row["produced_by"] == "writer"
         assert row["completion_packet_id"] == "packet-1"
-        assert ledger.claim_verification("write-1", "verifier-b", now=NOW + timedelta(seconds=62)).claimed
+        assert _claim_verification(ledger, "verifier-b", now=NOW + timedelta(seconds=62)).claimed
+    finally:
+        ledger.close()
+
+
+def test_verification_claim_requires_atomic_independence_decision(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.sqlite3")
+    try:
+        _claimed_writer(ledger)
+        ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
+
+        missing = ledger.claim_verification("write-1", "verifier-a", now=NOW)
+        assert not missing.claimed and missing.reason == "verification_decision_required"
+
+        same_group = _verification_decision("verifier-a", verifier_group="producer-group")
+        denied = ledger.claim_verification("write-1", "verifier-a", decision=same_group, now=NOW)
+        assert not denied.claimed and denied.reason == "verifier_not_independent"
+
+        missing_group = _verification_decision("verifier-a", verifier_group=None)
+        denied = ledger.claim_verification("write-1", "verifier-a", decision=missing_group, now=NOW)
+        assert not denied.claimed and denied.reason == "verifier_not_independent"
+
+        selected_other = _verification_decision("verifier-b")
+        denied = ledger.claim_verification("write-1", "verifier-a", decision=selected_other, now=NOW)
+        assert not denied.claimed and denied.reason == "verification_decision_mismatch"
+
+        wrong_producer = _verification_decision("verifier-a", producer_worker_id="other-writer")
+        denied = ledger.claim_verification("write-1", "verifier-a", decision=wrong_producer, now=NOW)
+        assert not denied.claimed and denied.reason == "verification_decision_mismatch"
+
+        assert _claim_verification(ledger, "verifier-a", now=NOW).claimed
     finally:
         ledger.close()

--- a/tests/test_autopilot_verifier_lifecycle.py
+++ b/tests/test_autopilot_verifier_lifecycle.py
@@ -83,6 +83,46 @@ def test_rejection_preserves_evidence_and_attempt_and_bounds_retry(tmp_path):
         ledger.close()
 
 
+def test_rejected_retry_can_be_rerouted_without_losing_producer_provenance(tmp_path):
+    """A rejected write may be rerouted, but the new attempt must own its submission.
+
+    AUTOPILOT-004 explicitly requires failed workers to be reroutable.  This test
+    prevents the task-level ``produced_by`` field from permanently binding every
+    future attempt to the first producer.  Historical producer evidence must remain
+    reconstructable in the event stream while the new worker becomes the producer
+    of the retry it actually performed.
+    """
+    ledger = TaskLedger(tmp_path / "ledger.sqlite3")
+    try:
+        _claimed_writer(ledger)
+        assert ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:first"], now=NOW)
+        assert ledger.claim_verification("write-1", "verifier-a", now=NOW).claimed
+        assert ledger.reject_verification(
+            "write-1", "verifier-a", "needs revision", ["review:first-fail"], max_rejections=3, now=NOW
+        )
+
+        retry_time = NOW + timedelta(minutes=1)
+        retry = ledger.claim("write-1", "writer-b", now=retry_time)
+        assert retry.claimed
+        assert ledger.submit_for_verification(
+            "write-1", "writer-b", "packet-2", ["evidence:retry"], now=retry_time
+        )
+
+        row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
+        assert row["status"] == "verifying"
+        assert row["produced_by"] == "writer-b"
+        assert row["completion_packet_id"] == "packet-2"
+        events = ledger.events("write-1")
+        first_submission = next(e for e in events if e["event_type"] == "producer_completion_submitted")
+        assert first_submission["actor"] == "writer"
+        assert first_submission["detail"]["packet_id"] == "packet-1"
+        assert events[-1]["event_type"] == "producer_completion_submitted"
+        assert events[-1]["actor"] == "writer-b"
+        assert events[-1]["detail"]["packet_id"] == "packet-2"
+    finally:
+        ledger.close()
+
+
 def test_expired_verifier_lease_reaps_without_touching_producer_evidence(tmp_path):
     ledger = TaskLedger(tmp_path / "ledger.sqlite3")
     try:

--- a/tests/test_autopilot_verifier_lifecycle.py
+++ b/tests/test_autopilot_verifier_lifecycle.py
@@ -9,48 +9,44 @@ from datetime import datetime, timedelta, timezone
 
 from elysia_collective_seed.autopilot.dispatcher import Worker
 from elysia_collective_seed.autopilot.task_ledger import TaskLedger
-from elysia_collective_seed.autopilot.verifier import select_verifier
 
 NOW = datetime(2026, 9, 9, 12, 0, tzinfo=timezone.utc)
 
 
 def _claimed_writer(ledger: TaskLedger, task_id: str = "write-1") -> None:
-    ledger.put_task({"task_id": task_id, "status": "queued", "title": "bounded local write"})
+    if not ledger.verification_workers:
+        ledger.verification_workers = {
+            worker_id: Worker(
+                worker_id,
+                "test",
+                frozenset({"verification"}),
+                frozenset({"repo_write"}),
+                quality=1.0 if worker_id == "verifier-a" else 0.9,
+            )
+            for worker_id in ("verifier-a", "verifier-b")
+        }
+        ledger.independence_groups = {
+            "writer": "producer-group",
+            "writer-b": "producer-b-group",
+            "verifier-a": "verifier-group-a",
+            "verifier-b": "verifier-group-b",
+        }
+    ledger.put_task({
+        "task_id": task_id,
+        "status": "queued",
+        "title": "bounded local write",
+        "objective": "change only the approved local repository scope",
+        "risk_class": "repo_write",
+        "required_capabilities": ["verification"],
+        "human_approval_required": False,
+        "source_refs": ["issue:#17"],
+        "acceptance_criteria": ["tests pass"],
+    })
     assert ledger.claim(task_id, "writer", now=NOW).claimed
 
 
-def _verification_decision(
-    verifier_worker_id: str,
-    *,
-    producer_worker_id: str = "writer",
-    producer_group: str = "producer-group",
-    verifier_group: str | None = "verifier-group",
-):
-    verifier = Worker(
-        worker_id=verifier_worker_id,
-        provider="test",
-        capabilities=frozenset({"verification"}),
-        risk_classes=frozenset({"repo_write"}),
-        quality=1.0,
-    )
-    groups = {producer_worker_id: producer_group}
-    if verifier_group is not None:
-        groups[verifier_worker_id] = verifier_group
-    return select_verifier(
-        producer_worker_id=producer_worker_id,
-        producer_independence_group=producer_group,
-        workers=[verifier],
-        independence_groups=groups,
-    )
-
-
 def _claim_verification(ledger: TaskLedger, verifier_worker_id: str, **kwargs):
-    return ledger.claim_verification(
-        "write-1",
-        verifier_worker_id,
-        decision=_verification_decision(verifier_worker_id),
-        **kwargs,
-    )
+    return ledger.claim_verification("write-1", verifier_worker_id, **kwargs)
 
 
 def test_writer_submission_enters_verifying_and_releases_execution_lease(tmp_path):
@@ -74,9 +70,7 @@ def test_self_verification_forbidden_and_distinct_verifier_claims(tmp_path):
     try:
         _claimed_writer(ledger)
         ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
-        denied = ledger.claim_verification(
-            "write-1", "writer", decision=_verification_decision("writer"), now=NOW
-        )
+        denied = ledger.claim_verification("write-1", "writer", now=NOW)
         assert not denied.claimed and denied.reason == "self_verification_forbidden"
         claimed = _claim_verification(ledger, "verifier-a", now=NOW)
         assert claimed.claimed
@@ -95,6 +89,10 @@ def test_accept_requires_live_owner_and_records_decision(tmp_path):
         assert not ledger.accept_verification("write-1", "verifier-b", ["review:wrong"], now=NOW)
         assert not ledger.accept_verification("write-1", "verifier-a", ["review:stale"], now=NOW + timedelta(seconds=61))
         assert ledger.reap_expired_verification(now=NOW + timedelta(seconds=61)) == ["write-1"]
+        ledger.verification_workers["verifier-a"] = Worker(
+            "verifier-a", "test", frozenset({"verification"}), frozenset({"repo_write"}),
+            available=False, quality=1.0,
+        )
         assert _claim_verification(ledger, "verifier-b", lease_seconds=60, now=NOW + timedelta(seconds=62)).claimed
         assert ledger.accept_verification("write-1", "verifier-b", ["review:ok"], now=NOW + timedelta(seconds=63))
         row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
@@ -165,6 +163,14 @@ def test_expired_verifier_lease_reaps_without_touching_producer_evidence(tmp_pat
         assert row["attempt"] == attempt
         assert row["produced_by"] == "writer"
         assert row["completion_packet_id"] == "packet-1"
+        ledger.verification_workers["verifier-a"] = Worker(
+            "verifier-a",
+            "test",
+            frozenset({"verification"}),
+            frozenset({"repo_write"}),
+            available=False,
+            quality=1.0,
+        )
         assert _claim_verification(ledger, "verifier-b", now=NOW + timedelta(seconds=62)).claimed
     finally:
         ledger.close()
@@ -176,25 +182,97 @@ def test_verification_claim_requires_atomic_independence_decision(tmp_path):
         _claimed_writer(ledger)
         ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
 
-        missing = ledger.claim_verification("write-1", "verifier-a", now=NOW)
-        assert not missing.claimed and missing.reason == "verification_decision_required"
-
-        same_group = _verification_decision("verifier-a", verifier_group="producer-group")
-        denied = ledger.claim_verification("write-1", "verifier-a", decision=same_group, now=NOW)
+        ledger.independence_groups["verifier-a"] = "producer-group"
+        denied = ledger.claim_verification("write-1", "verifier-a", now=NOW)
         assert not denied.claimed and denied.reason == "verifier_not_independent"
 
-        missing_group = _verification_decision("verifier-a", verifier_group=None)
-        denied = ledger.claim_verification("write-1", "verifier-a", decision=missing_group, now=NOW)
+        del ledger.independence_groups["verifier-a"]
+        denied = ledger.claim_verification("write-1", "verifier-a", now=NOW)
         assert not denied.claimed and denied.reason == "verifier_not_independent"
 
-        selected_other = _verification_decision("verifier-b")
-        denied = ledger.claim_verification("write-1", "verifier-a", decision=selected_other, now=NOW)
-        assert not denied.claimed and denied.reason == "verification_decision_mismatch"
-
-        wrong_producer = _verification_decision("verifier-a", producer_worker_id="other-writer")
-        denied = ledger.claim_verification("write-1", "verifier-a", decision=wrong_producer, now=NOW)
-        assert not denied.claimed and denied.reason == "verification_decision_mismatch"
-
+        ledger.independence_groups["verifier-a"] = "verifier-group-a"
         assert _claim_verification(ledger, "verifier-a", now=NOW).claimed
     finally:
         ledger.close()
+
+
+def test_claim_rechecks_current_registry_eligibility(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.sqlite3")
+    try:
+        _claimed_writer(ledger)
+        ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:first"], now=NOW)
+        ledger.verification_workers["verifier-a"] = Worker(
+            "verifier-a",
+            "test",
+            frozenset({"verification"}),
+            frozenset({"repo_write"}),
+            available=False,
+        )
+        denied = ledger.claim_verification("write-1", "verifier-a", now=NOW)
+        assert not denied.claimed and denied.reason == "verifier_not_independent"
+    finally:
+        ledger.close()
+
+
+def test_claim_enforces_task_specific_capability_and_risk(tmp_path):
+    worker = Worker(
+        "verifier-a", "test", frozenset({"verification"}), frozenset({"repo_write"}), quality=1.0
+    )
+    ledger = TaskLedger(
+        tmp_path / "ledger.sqlite3",
+        verification_workers=[worker],
+        independence_groups={"writer": "producer-group", "verifier-a": "verifier-group"},
+    )
+    try:
+        ledger.put_task({
+            "task_id": "write-1",
+            "status": "queued",
+            "title": "specialized write",
+            "risk_class": "sandbox_write",
+            "required_capabilities": ["specialized_review"],
+        })
+        assert ledger.claim("write-1", "writer", now=NOW).claimed
+        assert ledger.submit_for_verification("write-1", "writer", "packet-1", [], now=NOW)
+        denied = ledger.claim_verification("write-1", "verifier-a", now=NOW)
+        assert not denied.claimed and denied.reason == "verifier_not_independent"
+    finally:
+        ledger.close()
+
+
+def test_exhausted_retries_route_to_human_review_without_expanding_authority(tmp_path):
+    path = tmp_path / "ledger.sqlite3"
+    ledger = TaskLedger(path)
+    try:
+        _claimed_writer(ledger)
+        original_payload = dict(ledger.get("write-1"))
+        assert ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:one"], now=NOW)
+        assert _claim_verification(ledger, "verifier-a", now=NOW).claimed
+        assert ledger.reject_verification("write-1", "verifier-a", "retry", ["review:one"], max_rejections=2, now=NOW)
+
+        retry_time = NOW + timedelta(minutes=1)
+        assert ledger.claim("write-1", "writer-b", now=retry_time).claimed
+        assert ledger.submit_for_verification("write-1", "writer-b", "packet-2", ["evidence:two"], now=retry_time)
+        assert _claim_verification(ledger, "verifier-a", now=retry_time).claimed
+        assert ledger.reject_verification("write-1", "verifier-a", "still unsafe", ["review:two"], max_rejections=2, now=retry_time)
+
+        final = ledger.get("write-1")
+        assert final["status"] == "human_review"
+        for protected_field in ("title", "risk_class", "human_approval_required", "source_refs"):
+            assert final.get(protected_field) == original_payload.get(protected_field)
+        assert [event["event_type"] for event in ledger.events("write-1")].count("verification_rejected") == 2
+    finally:
+        ledger.close()
+
+    reopened = TaskLedger(path)
+    try:
+        assert reopened.get("write-1")["status"] == "human_review"
+        submissions = [
+            event for event in reopened.events("write-1")
+            if event["event_type"] == "producer_completion_submitted"
+        ]
+        assert [(event["actor"], event["detail"]["packet_id"]) for event in submissions] == [
+            ("writer", "packet-1"),
+            ("writer-b", "packet-2"),
+        ]
+    finally:
+        reopened.close()

--- a/tests/test_autopilot_verifier_lifecycle.py
+++ b/tests/test_autopilot_verifier_lifecycle.py
@@ -1,0 +1,101 @@
+"""Executable acceptance contract for AUTOPILOT-004 verifier ledger lifecycle.
+
+These tests are local-only and intentionally drive the remaining implementation.
+They grant no provider, merge, deploy, external-write, credential, or private-data authority.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from elysia_collective_seed.autopilot.task_ledger import TaskLedger
+
+NOW = datetime(2026, 9, 9, 12, 0, tzinfo=timezone.utc)
+
+
+def _claimed_writer(ledger: TaskLedger, task_id: str = "write-1") -> None:
+    ledger.put_task({"task_id": task_id, "status": "queued", "title": "bounded local write"})
+    assert ledger.claim(task_id, "writer", now=NOW).claimed
+
+
+def test_writer_submission_enters_verifying_and_releases_execution_lease(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.sqlite3")
+    try:
+        _claimed_writer(ledger)
+        assert ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
+        row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
+        assert row["status"] == "verifying"
+        assert row["claimed_by"] is None and row["lease_expires_at"] is None
+        assert row["produced_by"] == "writer"
+        assert row["completion_packet_id"] == "packet-1"
+        assert not ledger.claim("write-1", "writer", now=NOW).claimed
+        assert ledger.events("write-1")[-1]["event_type"] == "producer_completion_submitted"
+    finally:
+        ledger.close()
+
+
+def test_self_verification_forbidden_and_distinct_verifier_claims(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.sqlite3")
+    try:
+        _claimed_writer(ledger)
+        ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
+        denied = ledger.claim_verification("write-1", "writer", now=NOW)
+        assert not denied.claimed and denied.reason == "self_verification_forbidden"
+        claimed = ledger.claim_verification("write-1", "verifier-a", now=NOW)
+        assert claimed.claimed
+        competing = ledger.claim_verification("write-1", "verifier-b", now=NOW)
+        assert not competing.claimed
+    finally:
+        ledger.close()
+
+
+def test_accept_requires_live_owner_and_records_decision(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.sqlite3")
+    try:
+        _claimed_writer(ledger)
+        ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
+        ledger.claim_verification("write-1", "verifier-a", lease_seconds=60, now=NOW)
+        assert not ledger.accept_verification("write-1", "verifier-b", ["review:wrong"], now=NOW)
+        assert not ledger.accept_verification("write-1", "verifier-a", ["review:stale"], now=NOW + timedelta(seconds=61))
+        assert ledger.accept_verification("write-1", "verifier-a", ["review:ok"], now=NOW + timedelta(seconds=30))
+        row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
+        assert row["status"] == "completed"
+        assert row["verification_claimed_by"] is None
+        assert ledger.events("write-1")[-1]["event_type"] == "verification_accepted"
+    finally:
+        ledger.close()
+
+
+def test_rejection_preserves_evidence_and_attempt_and_bounds_retry(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.sqlite3")
+    try:
+        _claimed_writer(ledger)
+        attempt = ledger.get("write-1")["attempt"]
+        ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
+        ledger.claim_verification("write-1", "verifier-a", now=NOW)
+        assert ledger.reject_verification("write-1", "verifier-a", "test failure", ["review:fail"], max_rejections=2, now=NOW)
+        row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
+        assert row["status"] == "queued"
+        assert row["attempt"] == attempt
+        assert row["completion_packet_id"] == "packet-1"
+        assert "evidence:test" in row["completion_evidence_json"]
+        assert row["verification_rejections"] == 1
+    finally:
+        ledger.close()
+
+
+def test_expired_verifier_lease_reaps_without_touching_producer_evidence(tmp_path):
+    ledger = TaskLedger(tmp_path / "ledger.sqlite3")
+    try:
+        _claimed_writer(ledger)
+        attempt = ledger.get("write-1")["attempt"]
+        ledger.submit_for_verification("write-1", "writer", "packet-1", ["evidence:test"], now=NOW)
+        ledger.claim_verification("write-1", "verifier-a", lease_seconds=60, now=NOW)
+        assert ledger.reap_expired_verification(now=NOW + timedelta(seconds=61)) == ["write-1"]
+        row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
+        assert row["status"] == "verifying"
+        assert row["attempt"] == attempt
+        assert row["produced_by"] == "writer"
+        assert row["completion_packet_id"] == "packet-1"
+        assert ledger.claim_verification("write-1", "verifier-b", now=NOW + timedelta(seconds=62)).claimed
+    finally:
+        ledger.close()

--- a/tests/test_autopilot_verifier_lifecycle.py
+++ b/tests/test_autopilot_verifier_lifecycle.py
@@ -56,7 +56,9 @@ def test_accept_requires_live_owner_and_records_decision(tmp_path):
         ledger.claim_verification("write-1", "verifier-a", lease_seconds=60, now=NOW)
         assert not ledger.accept_verification("write-1", "verifier-b", ["review:wrong"], now=NOW)
         assert not ledger.accept_verification("write-1", "verifier-a", ["review:stale"], now=NOW + timedelta(seconds=61))
-        assert ledger.accept_verification("write-1", "verifier-a", ["review:ok"], now=NOW + timedelta(seconds=30))
+        assert ledger.reap_expired_verification(now=NOW + timedelta(seconds=61)) == ["write-1"]
+        assert ledger.claim_verification("write-1", "verifier-b", lease_seconds=60, now=NOW + timedelta(seconds=62)).claimed
+        assert ledger.accept_verification("write-1", "verifier-b", ["review:ok"], now=NOW + timedelta(seconds=63))
         row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
         assert row["status"] == "completed"
         assert row["verification_claimed_by"] is None
@@ -84,14 +86,7 @@ def test_rejection_preserves_evidence_and_attempt_and_bounds_retry(tmp_path):
 
 
 def test_rejected_retry_can_be_rerouted_without_losing_producer_provenance(tmp_path):
-    """A rejected write may be rerouted, but the new attempt must own its submission.
-
-    AUTOPILOT-004 explicitly requires failed workers to be reroutable.  This test
-    prevents the task-level ``produced_by`` field from permanently binding every
-    future attempt to the first producer.  Historical producer evidence must remain
-    reconstructable in the event stream while the new worker becomes the producer
-    of the retry it actually performed.
-    """
+    """A rejected write may be rerouted, but the new attempt must own its submission."""
     ledger = TaskLedger(tmp_path / "ledger.sqlite3")
     try:
         _claimed_writer(ledger)
@@ -100,14 +95,10 @@ def test_rejected_retry_can_be_rerouted_without_losing_producer_provenance(tmp_p
         assert ledger.reject_verification(
             "write-1", "verifier-a", "needs revision", ["review:first-fail"], max_rejections=3, now=NOW
         )
-
         retry_time = NOW + timedelta(minutes=1)
         retry = ledger.claim("write-1", "writer-b", now=retry_time)
         assert retry.claimed
-        assert ledger.submit_for_verification(
-            "write-1", "writer-b", "packet-2", ["evidence:retry"], now=retry_time
-        )
-
+        assert ledger.submit_for_verification("write-1", "writer-b", "packet-2", ["evidence:retry"], now=retry_time)
         row = ledger.conn.execute("SELECT * FROM tasks WHERE task_id='write-1'").fetchone()
         assert row["status"] == "verifying"
         assert row["produced_by"] == "writer-b"

--- a/tests/test_vega_verifier_boundaries.py
+++ b/tests/test_vega_verifier_boundaries.py
@@ -1,0 +1,108 @@
+"""Independent safety falsification for PR #15; synthetic SQLite only."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from elysia_collective_seed.autopilot.dispatcher import Worker
+from elysia_collective_seed.autopilot.dryrun_orchestrator import validate_and_apply_completion
+from elysia_collective_seed.autopilot.task_ledger import TaskLedger
+
+NOW = datetime(2026, 9, 10, tzinfo=timezone.utc)
+
+
+def open_ledger(path):
+    return TaskLedger(path, verification_workers=[
+        Worker("reviewer", "synthetic", frozenset({"verification"}), frozenset({"repo_write"}))
+    ], independence_groups={"writer": "a", "writer-b": "b", "reviewer": "c"})
+
+
+def task(**overrides):
+    result = dict(task_id="vega", status="queued", title="Synthetic write",
+                  objective="Test only", risk_class="repo_write", max_attempts=1,
+                  human_approval_required=False, required_capabilities=["verification"],
+                  acceptance_criteria=["independent verification"], source_refs=["synthetic:test"])
+    result.update(overrides)
+    return result
+
+
+@pytest.mark.parametrize("expired", [False, True])
+def test_execution_budget_survives_reopen(tmp_path, expired):
+    path = tmp_path / "ledger.db"
+    ledger = open_ledger(path)
+    ledger.put_task(task())
+    assert ledger.claim("vega", "writer", lease_seconds=1, now=NOW).claimed
+    if not expired:
+        assert ledger.release("vega", "writer", now=NOW)
+    ledger.close()
+    ledger = open_ledger(path)
+    try:
+        second = ledger.claim("vega", "writer-b", now=NOW + timedelta(seconds=2))
+        assert not second.claimed, f"max_attempts=1 bypassed: {second}; attempt={ledger.get('vega')['attempt']}"
+    finally:
+        ledger.close()
+
+
+def test_rejection_ceiling_cannot_be_raised_after_reopen(tmp_path):
+    path = tmp_path / "ledger.db"
+    ledger = open_ledger(path)
+    ledger.put_task(task(max_attempts=3))
+    try:
+        for index, ceiling in enumerate((2, 9999)):
+            assert ledger.claim("vega", "writer", now=NOW).claimed
+            assert ledger.submit_for_verification("vega", "writer", f"packet-{index}", ["synthetic:evidence"], now=NOW)
+            assert ledger.claim_verification("vega", "reviewer", now=NOW).claimed
+            ledger.reject_verification("vega", "reviewer", "failure", [], max_rejections=ceiling, now=NOW)
+            ledger.close()
+            ledger = open_ledger(path)
+        state = ledger.get("vega")
+        assert state["status"] != "queued", f"Caller raised established ceiling: {state}"
+    finally:
+        ledger.close()
+
+
+def test_producer_cannot_release_write_directly_to_completed(tmp_path):
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        ledger.put_task(task())
+        assert ledger.claim("vega", "writer", now=NOW).claimed
+        ledger.release("vega", "writer", next_status="completed", now=NOW)
+        assert ledger.get("vega")["status"] != "completed", ledger.events("vega")
+    finally:
+        ledger.close()
+
+
+def test_validated_completion_reaches_independent_verifier(tmp_path):
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        ledger.put_task(task())
+        assert ledger.claim("vega", "writer").claimed
+        packet = dict(task_id="vega", packet_id="packet-1", evidence_refs=["synthetic:evidence"],
+                      worker={"provider": "synthetic", "role": "engineer"}, outcome="completed",
+                      summary="Synthetic result", checks=[{"name": "unit", "result": "pass"}],
+                      next_recommendation={"action": "verify"})
+        result = validate_and_apply_completion(ledger, packet, worker_id="writer", required_checks=("unit",))
+        assert result.applied, result
+        claim = ledger.claim_verification("vega", "reviewer")
+        assert claim.claimed, f"Completion cannot reach verifier: {claim}; row={ledger.get('vega')}"
+        assert ledger.get("vega")["produced_by"] == "writer"
+        assert ledger.accept_verification("vega", "reviewer", ["synthetic:review"])
+    finally:
+        ledger.close()
+
+
+def test_rerouted_retry_refuses_old_producer_and_current_self_review(tmp_path):
+    ledger = open_ledger(tmp_path / "ledger.db")
+    try:
+        ledger.put_task(task(max_attempts=2))
+        assert ledger.claim("vega", "writer", now=NOW).claimed
+        assert ledger.submit_for_verification("vega", "writer", "packet-1", ["first"], now=NOW)
+        assert ledger.claim_verification("vega", "reviewer", now=NOW).claimed
+        assert ledger.reject_verification("vega", "reviewer", "retry", [], now=NOW)
+        assert ledger.claim("vega", "writer-b", now=NOW).claimed
+        assert not ledger.submit_for_verification("vega", "writer", "stale", [], now=NOW)
+        assert ledger.submit_for_verification("vega", "writer-b", "packet-2", ["second"], now=NOW)
+        assert ledger.claim_verification("vega", "writer-b", now=NOW).reason == "self_verification_forbidden"
+        submissions = [e for e in ledger.events("vega") if e["event_type"] == "producer_completion_submitted"]
+        assert [(e["actor"], e["detail"]["evidence_refs"]) for e in submissions] == [("writer", ["first"]), ("writer-b", ["second"])]
+    finally:
+        ledger.close()


### PR DESCRIPTION
Implements the runtime-disabled local SQLite verifier lifecycle for AUTOPILOT-004. Producer submission persists attempt provenance and routes work to a distinct eligible verifier; lease ownership, migration, rejection/reclaim and audit history are covered by executable tests.

## Governance repairs
Exact head: `6649b89adea44e3e7f41d37b55a7c82485beb6e6`.

- #20: generic release cannot complete consequential writes; ungated read-only completion requires a live lease. Existing-task upserts cannot change admitted policy/status.
- #19: persisted validated execution limits and persisted system rejection ceiling are enforced at ledger transitions. Exhaustion routes to human_review; caller rejection limits cannot alter policy.
- #21: validated completion invokes persistent producer submission with packet identity, evidence/checks and live lease provenance; independent verifier claim/acceptance works across reopen.
- CI mandates seed, existing verifier/migration/lifecycle, unchanged Vega falsification and new repair suites on the exact source head.

## Validation
- 92 tests pass locally and in [exact-head GitHub Actions](https://github.com/MsElysia/Elysia/actions/runs/34471848713).
- Compile checks, JSON parsing and runtime-disable gate pass.
- Vega's six tests from `1326aa7` remain unchanged.
- Independent pre-handoff review found no blocking scoped findings; **final independent Vega re-verification remains requested**.

## Handoff and gates
[Structured repair handoff](https://github.com/MsElysia/Elysia/blob/6649b89/elysia_collective_seed/autopilot/handoffs/PR15-lifecycle-repair-20260910.md). Keep draft and unmerged; issues #19/#20/#21 remain open pending independent verdict. Trusted task admission and direct process/SQLite access are explicit boundaries; this is not full Guardian certification.

No provider/model invocation, Guardian runtime activation, deployment, merge, external posting capability, credential/private-data authority or unrelated feature expansion is enabled.

Refs #8, #11, #16, #17, #19, #20, #21.