### PR TITLE
Issue #23: audit-safe Guardian bootstrap descriptor [DRAFT]

### DIFF
--- a/docs/ISSUE-23-AUDIT-BOOTSTRAP.md
+++ b/docs/ISSUE-23-AUDIT-BOOTSTRAP.md
@@ -1,0 +1,63 @@
+# Issue #23 — Audit-safe bootstrap (bounded completion)
+
+## ISSUE
+#23 EREBUS-003A-001: canonical runtime verification path has implicit active side effects
+
+## STARTING STATE
+- Primary dirty workspace: `elysia-local-reconciliation-20260909-1657` @ `4d9fceb` (untouched)
+- Codex unfinished WIP recovered from `C:\Users\Owner\guardian-remote-fix-23`
+  - branch `codex/remote-fix-23-bootstrap-mode`
+  - preserved locally as `d864f59` (WIP/unverified commit; not discarded)
+- Cursor branch: `cursor/guardian-23-audit-bootstrap` from `4d9fceb`
+
+## UNFINISHED CODE RECOVERED
+Codex draft introduced:
+- required keyword `mode: audit|operational` on `init_guardian_core`
+- `GuardianBootstrapAudit` pure descriptor for audit
+- operational path gated by `enable_background_services`
+- singleton reject when caller disables flags against stronger live instance
+- `elysia.py` passes `mode="operational"`
+
+Treated as unfinished/unverified; completed with docs, public `describe_guardian_bootstrap`, and adversarial tests.
+
+## BOOT PATH (authoritative map)
+
+```
+elysia.py UnifiedElysiaSystem
+  → init_guardian_core(..., mode="operational")   # only production caller
+      → _normalize_config(use_environment=True)
+      → get_guardian_core(config)                 # GuardianCore.__init__ (SIDE EFFECTS)
+      → ensure_monitoring_started (if bg on)      # monitor / ElysiaLoop / prompt evolver
+      → schedule_upstream_routing_live_probes     # conditional Timer
+
+init_guardian_core(..., mode="audit")
+  → GuardianBootstrapAudit(normalized config)     # NO core, NO activation
+
+BYPASS (still active; remaining #23 work):
+  get_guardian_core / direct GuardianCore(...)
+    → __init__ may start UI, monitor, health, planner probe
+```
+
+## IMPLEMENTATION
+- Authoritative audit boundary on `init_guardian_core` / `describe_guardian_bootstrap`
+- Audit never imports/constructs GuardianCore
+- Explicit limitation string: descriptor does not prove live wiring
+- Operational opt-out via `enable_background_services=False` preserved
+- Tests: `tests/test_guardian_audit_bootstrap.py`
+
+## SAFETY INVARIANTS (audit mode)
+- No GuardianCore construction
+- No monitoring / ElysiaLoop / prompt-evolution start
+- No UI auto-start
+- No live-routing probe scheduling
+- No env-driven limit overrides
+- No socket/subprocess/thread activation from the audit path itself
+
+## REMAINING LIMITATIONS (do not close #23 fully)
+True construct-without-activate is **not** delivered: `GuardianCore.__init__` /
+`get_guardian_core` can still auto-start when used directly. Next bounded task:
+move activation out of `__init__` behind an explicit activate API and default
+`get_guardian_core` to non-activating construction.
+
+## TESTS
+See commit message / CI local run.

--- a/elysia.py
+++ b/elysia.py
@@ -648,7 +648,7 @@ class UnifiedElysiaSystem:
         logger.info("Unified Elysia System initialized successfully")
 
         # [1/5] Guardian Core first (Architect's WebScout needs web_reader from Guardian)
-        self.guardian = init_guardian_core(config=self.config)
+        self.guardian = init_guardian_core(config=self.config, mode="operational")
         self.openclaw = OpenClawAdapter(config_path=str(PROJECT_ROOT / "config" / "openclaw.json"))
 
         # [2/5] Architect-Core

--- a/elysia_sub_guardian.py
+++ b/elysia_sub_guardian.py
@@ -2,7 +2,8 @@
 """Elysia subroutine: Initialize Guardian Core (singleton)."""
 import os
 import logging
-from typing import Any, Dict, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Literal
 
 logger = logging.getLogger(__name__)
 
@@ -21,74 +22,133 @@ def _parse_resource_limit(env_var: str, default: float) -> float:
     return default
 
 
-def init_guardian_core(config: Optional[Dict[str, Any]] = None) -> Optional[Any]:
+@dataclass(frozen=True)
+class GuardianBootstrapAudit:
+    """Pure configuration preview for Issue #23 audit/inspection bootstrap.
+
+    This object describes *intended* normalized Guardian config defaults only.
+    It does **not** construct GuardianCore, start monitoring/ElysiaLoop/UI,
+    schedule probes, touch providers/network, or prove live runtime wiring.
     """
-    Initialize Project Guardian Core (singleton).
-    Must run before Architect (WebScout needs web_reader from Guardian).
-    Returns GuardianCore instance or None on failure.
+
+    config: Dict[str, Any]
+    mode: Literal["audit"] = "audit"
+    runtime_constructed: bool = False
+    runtime_wiring_verified: bool = False
+    limitation: str = (
+        "descriptor_only: architecture/configuration preview; "
+        "does not prove live runtime wiring or capability reachability"
+    )
+
+
+def _normalize_config(config: Optional[Dict[str, Any]], *, use_environment: bool) -> Dict[str, Any]:
+    cfg = config or {}
+    # Resource limits: config first, then env (ELYSIA_MEMORY_LIMIT=0.9), then default
+    res_cfg = cfg.get("resource_limits", {})
+    memory_limit = res_cfg.get("memory_limit")
+    if memory_limit is None:
+        memory_limit = (_parse_resource_limit("ELYSIA_MEMORY_LIMIT", 0.92) if use_environment else 0.92)
+    # UI Control Panel / dashboard (enabled by default; override via cfg["ui_config"])
+    _ui_cfg = cfg.get("ui_config", {})
+    ui_config = {
+        "enabled": _ui_cfg.get("enabled", True),
+        "auto_start": _ui_cfg.get("auto_start", True),
+        "host": _ui_cfg.get("host", "127.0.0.1"),
+        "port": _ui_cfg.get("port", 5000),
+        "debug": _ui_cfg.get("debug", False),
+    }
+    # Memory cleanup: trigger when memory_log exceeds this count (default 3500)
+    memory_cleanup_threshold = cfg.get("memory_cleanup_threshold")
+    if memory_cleanup_threshold is None:
+        try:
+            memory_cleanup_threshold = int((os.environ.get("ELYSIA_MEMORY_CLEANUP_THRESHOLD", "3500") if use_environment else "3500"))
+        except (ValueError, TypeError):
+            memory_cleanup_threshold = 3500
+
+    # memory_filepath is canonical; memory_file is legacy alias
+    _mem = cfg.get("memory_filepath") or cfg.get("memory_file")
+    guardian_config = {
+        "defer_heavy_startup": cfg.get("defer_heavy_startup", True),
+        "trust_file": cfg.get("trust_file", "enhanced_trust.json"),
+        "tasks_file": cfg.get("tasks_file", "enhanced_tasks.json"),
+        "memory_cleanup_threshold": memory_cleanup_threshold,
+        "enable_background_services": cfg.get("enable_background_services", True),
+        "enable_resource_monitoring": cfg.get("enable_resource_monitoring", True),
+        "enable_runtime_health_monitoring": cfg.get("enable_runtime_health_monitoring", True),
+        "enable_upstream_routing_live_probes": cfg.get("enable_upstream_routing_live_probes", True),
+        "resource_limits": {
+            "memory_limit": memory_limit,
+            "cpu_limit": res_cfg.get("cpu_limit", (_parse_resource_limit("ELYSIA_CPU_LIMIT", 0.9) if use_environment else 0.9)),
+            "disk_limit": res_cfg.get("disk_limit", 0.9),
+        },
+        "ui_config": ui_config,
+    }
+    if _mem is not None:
+        guardian_config["memory_filepath"] = _mem
+    if not guardian_config["enable_background_services"]:
+        guardian_config["enable_resource_monitoring"] = False
+        guardian_config["enable_runtime_health_monitoring"] = False
+        guardian_config["enable_upstream_routing_live_probes"] = False
+        guardian_config["ui_config"]["auto_start"] = False
+    return guardian_config
+
+
+def describe_guardian_bootstrap(config: Optional[Dict[str, Any]] = None) -> GuardianBootstrapAudit:
+    """Public audit/inspection entrypoint: configuration descriptor only.
+
+    Equivalent to ``init_guardian_core(..., mode=\"audit\")``. Prefer this name
+    when the caller intends inspection rather than activation.
     """
+    return init_guardian_core(config, mode="audit")
+
+
+def init_guardian_core(config: Optional[Dict[str, Any]] = None, *, mode: Literal["audit", "operational"]) -> Any:
+    """Authoritative Guardian bootstrap boundary (Issue #23).
+
+    ``mode`` is required and keyword-only — callers must choose explicitly:
+
+    * ``audit`` — pure config descriptor (`GuardianBootstrapAudit`). Never
+      imports/constructs GuardianCore, never starts monitoring/loop/UI/probes,
+      never reads activation-related env overrides. Does **not** prove live
+      runtime wiring.
+    * ``operational`` — existing active bootstrap via singleton. May start
+      background services when config allows. Opt out with
+      ``enable_background_services=False`` (forces monitoring/probes/UI
+      auto-start off at normalize time).
+
+    Lower-level ``get_guardian_core`` / ``GuardianCore.__init__`` remain capable
+    of activation when called directly; they are **not** the audit path.
+    """
+    if mode not in ("audit", "operational"):
+        raise ValueError("mode must be 'audit' or 'operational'")
+    if mode == "audit":
+        # No project_guardian imports: keep audit free of construction side effects.
+        return GuardianBootstrapAudit(_normalize_config(config, use_environment=False))
+
     logger.info("[1/5] Initializing Guardian Core...")
     try:
         from project_guardian.guardian_singleton import get_guardian_core, ensure_monitoring_started
-        cfg = config or {}
-        # Resource limits: config first, then env (ELYSIA_MEMORY_LIMIT=0.9), then default
-        res_cfg = cfg.get("resource_limits", {})
-        memory_limit = res_cfg.get("memory_limit")
-        if memory_limit is None:
-            memory_limit = _parse_resource_limit("ELYSIA_MEMORY_LIMIT", 0.92)
-        # UI Control Panel / dashboard (enabled by default; override via cfg["ui_config"])
-        _ui_cfg = cfg.get("ui_config", {})
-        ui_config = {
-            "enabled": _ui_cfg.get("enabled", True),
-            "auto_start": _ui_cfg.get("auto_start", True),
-            "host": _ui_cfg.get("host", "127.0.0.1"),
-            "port": _ui_cfg.get("port", 5000),
-            "debug": _ui_cfg.get("debug", False),
-        }
-        # Memory cleanup: trigger when memory_log exceeds this count (default 3500)
-        memory_cleanup_threshold = cfg.get("memory_cleanup_threshold")
-        if memory_cleanup_threshold is None:
-            try:
-                memory_cleanup_threshold = int(os.environ.get("ELYSIA_MEMORY_CLEANUP_THRESHOLD", "3500"))
-            except (ValueError, TypeError):
-                memory_cleanup_threshold = 3500
-
-        # memory_filepath is canonical; memory_file is legacy alias
-        _mem = cfg.get("memory_filepath") or cfg.get("memory_file")
-        guardian_config = {
-            "defer_heavy_startup": cfg.get("defer_heavy_startup", True),
-            "trust_file": cfg.get("trust_file", "enhanced_trust.json"),
-            "tasks_file": cfg.get("tasks_file", "enhanced_tasks.json"),
-            "memory_cleanup_threshold": memory_cleanup_threshold,
-            "enable_resource_monitoring": True,
-            "enable_runtime_health_monitoring": True,
-            "resource_limits": {
-                "memory_limit": memory_limit,
-                "cpu_limit": res_cfg.get("cpu_limit") or _parse_resource_limit("ELYSIA_CPU_LIMIT", 0.9),
-                "disk_limit": res_cfg.get("disk_limit", 0.9),
-            },
-            "ui_config": ui_config,
-        }
-        if _mem is not None:
-            guardian_config["memory_filepath"] = _mem
+        guardian_config = _normalize_config(config, use_environment=True)
+        memory_limit = guardian_config["resource_limits"]["memory_limit"]
         guardian = get_guardian_core(config=guardian_config)
         if guardian:
-            ensure_monitoring_started(guardian)
+            if guardian_config["enable_background_services"]:
+                ensure_monitoring_started(guardian)
             logger.info("  [OK] Guardian Core initialized (singleton)")
             if memory_limit != 0.8:
                 logger.info(f"  [Config] Memory limit: {memory_limit:.0%} (set via config or ELYSIA_MEMORY_LIMIT)")
-            try:
-                from project_guardian.diagnostics.upstream_routing_live_probe import (
-                    schedule_upstream_routing_live_probes,
-                )
+            if guardian_config["enable_upstream_routing_live_probes"]:
+                try:
+                    from project_guardian.diagnostics.upstream_routing_live_probe import (
+                        schedule_upstream_routing_live_probes,
+                    )
 
-                schedule_upstream_routing_live_probes(guardian)
-            except Exception as _diag_e:
-                logger.debug("upstream_routing_live_probe schedule: %s", _diag_e)
+                    schedule_upstream_routing_live_probes(guardian)
+                except Exception as _diag_e:
+                    logger.debug("upstream_routing_live_probe schedule: %s", _diag_e)
             return guardian
-        else:
-            logger.error("  [FAIL] Guardian Core initialization returned None")
-            return None
+        logger.error("  [FAIL] Guardian Core initialization returned None")
+        return None
     except Exception as e:
         logger.error(f"  [FAIL] Guardian Core failed: {e}")
         import traceback

--- a/project_guardian/guardian_singleton.py
+++ b/project_guardian/guardian_singleton.py
@@ -54,6 +54,18 @@ def get_guardian_core(
     
     with _guardian_core_lock:
         if _guardian_core_instance is not None and not force_new:
+            # Disabling a service cannot retroactively change a running singleton.
+            # Reject instead of silently returning an instance with weaker policy.
+            existing = getattr(_guardian_core_instance, "config", {})
+            requested = config or {}
+            for key in ("enable_background_services", "enable_resource_monitoring",
+                        "enable_runtime_health_monitoring", "enable_upstream_routing_live_probes"):
+                if requested.get(key) is False and existing.get(key, True) is not False:
+                    raise ValueError(f"Existing GuardianCore conflicts with disabled {key}")
+            for key in ("enabled", "auto_start"):
+                if (requested.get("ui_config", {}).get(key) is False
+                        and existing.get("ui_config", {}).get(key, True) is not False):
+                    raise ValueError(f"Existing GuardianCore conflicts with disabled ui_config.{key}")
             logger.debug("Returning existing GuardianCore instance")
             return _guardian_core_instance
         
@@ -147,6 +159,8 @@ def ensure_monitoring_started(guardian_core: Any) -> bool:
     global _monitoring_started
     
     with _monitoring_lock:
+        if not getattr(guardian_core, "config", {}).get("enable_background_services", True):
+            return False
         if _monitoring_started:
             logger.debug("Monitoring already started, skipping")
             return True

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ markers =
     asyncio: async test (requires pytest-asyncio)
     meta: tests that enforce repository test coverage or policy invariants
     slow: GuardianCore or network-heavy; exclude with -m "not slow"
+    no_guardian_core: Issue #23 audit bootstrap tests that must not import GuardianCore
 addopts = 
     -v
     --tb=short

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,15 @@ from typing import Dict, Any
 
 
 @pytest.fixture(autouse=True)
-def _isolate_guardian_core_singleton_between_tests():
-    """Prevent GuardianCore class/singleton state leaking across tests/."""
+def _isolate_guardian_core_singleton_between_tests(request):
+    """Prevent GuardianCore class/singleton state leaking across tests/.
+
+    Tests marked ``no_guardian_core`` (Issue #23 audit bootstrap) must not
+    import GuardianCore at all — skip singleton reset for those cases.
+    """
+    if request.node.get_closest_marker("no_guardian_core"):
+        yield
+        return
     from tests.guardian_core_test_helpers import reset_guardian_core_test_state
 
     reset_guardian_core_test_state()

--- a/tests/test_guardian_audit_bootstrap.py
+++ b/tests/test_guardian_audit_bootstrap.py
@@ -1,0 +1,159 @@
+"""Issue #23 adversarial tests: audit bootstrap must not activate Guardian.
+
+These tests prove `init_guardian_core(mode=\"audit\")` is a pure configuration
+descriptor. It must not construct GuardianCore, start monitoring/ElysiaLoop/
+prompt-evolution, auto-start UI, schedule live probes, open sockets, or spawn
+subprocesses. It does **not** prove live runtime wiring.
+
+Marked ``no_guardian_core`` so root conftest does not import GuardianCore.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.no_guardian_core
+
+from elysia_sub_guardian import (
+    GuardianBootstrapAudit,
+    describe_guardian_bootstrap,
+    init_guardian_core,
+)
+
+
+class _ActivationForbidden(AssertionError):
+    pass
+
+
+def _fail(*_a, **_k):
+    raise _ActivationForbidden("operational side effect attempted during audit")
+
+
+def _purge_project_guardian_modules() -> None:
+    for name in list(sys.modules):
+        if name == "project_guardian" or name.startswith("project_guardian."):
+            del sys.modules[name]
+
+
+def _install_fake_singleton(*, get_core, ensure=None, schedule=None):
+    """Install lightweight stubs so operational tests never import real GuardianCore."""
+    pg = types.ModuleType("project_guardian")
+    pg.__path__ = []  # mark as package
+    singleton = types.ModuleType("project_guardian.guardian_singleton")
+    singleton.get_guardian_core = get_core
+    singleton.ensure_monitoring_started = ensure or MagicMock(side_effect=_fail)
+    diagnostics = types.ModuleType("project_guardian.diagnostics")
+    diagnostics.__path__ = []
+    probe = types.ModuleType("project_guardian.diagnostics.upstream_routing_live_probe")
+    probe.schedule_upstream_routing_live_probes = schedule or MagicMock(side_effect=_fail)
+    return {
+        "project_guardian": pg,
+        "project_guardian.guardian_singleton": singleton,
+        "project_guardian.diagnostics": diagnostics,
+        "project_guardian.diagnostics.upstream_routing_live_probe": probe,
+    }
+
+
+@pytest.fixture
+def forbid_activation():
+    """Fail immediately on network/subprocess/thread activation surfaces."""
+    with patch("socket.socket", side_effect=_fail), patch(
+        "socket.create_connection", side_effect=_fail
+    ), patch("subprocess.Popen", side_effect=_fail), patch(
+        "subprocess.run", side_effect=_fail
+    ), patch("subprocess.call", side_effect=_fail), patch(
+        "threading.Thread", side_effect=_fail
+    ):
+        yield
+
+
+def test_audit_mode_requires_explicit_keyword():
+    with pytest.raises(TypeError):
+        init_guardian_core({})  # type: ignore[call-arg]
+
+
+def test_audit_returns_descriptor_not_core(forbid_activation):
+    result = init_guardian_core({"enable_background_services": True}, mode="audit")
+    assert isinstance(result, GuardianBootstrapAudit)
+    assert result.mode == "audit"
+    assert result.runtime_constructed is False
+    assert result.runtime_wiring_verified is False
+    assert "descriptor_only" in result.limitation
+    assert isinstance(result.config, dict)
+
+
+def test_describe_guardian_bootstrap_alias(forbid_activation):
+    desc = describe_guardian_bootstrap({"ui_config": {"auto_start": True}})
+    assert isinstance(desc, GuardianBootstrapAudit)
+    assert desc.runtime_wiring_verified is False
+
+
+def test_audit_does_not_load_project_guardian_package(forbid_activation):
+    _purge_project_guardian_modules()
+    init_guardian_core(
+        {
+            "enable_background_services": True,
+            "enable_resource_monitoring": True,
+            "enable_runtime_health_monitoring": True,
+            "enable_upstream_routing_live_probes": True,
+            "ui_config": {"enabled": True, "auto_start": True},
+        },
+        mode="audit",
+    )
+    loaded = [n for n in sys.modules if n == "project_guardian" or n.startswith("project_guardian.")]
+    assert loaded == [], f"audit loaded project_guardian modules: {loaded}"
+
+
+def test_audit_ignores_environment_for_limits(monkeypatch, forbid_activation):
+    monkeypatch.setenv("ELYSIA_MEMORY_LIMIT", "0.55")
+    monkeypatch.setenv("ELYSIA_CPU_LIMIT", "0.44")
+    monkeypatch.setenv("ELYSIA_MEMORY_CLEANUP_THRESHOLD", "123")
+    desc = init_guardian_core(mode="audit")
+    assert desc.config["resource_limits"]["memory_limit"] == 0.92
+    assert desc.config["resource_limits"]["cpu_limit"] == 0.9
+    assert desc.config["memory_cleanup_threshold"] == 3500
+
+
+def test_audit_twice_no_leaked_activation(forbid_activation):
+    _purge_project_guardian_modules()
+    a = init_guardian_core({"trust_file": "a.json"}, mode="audit")
+    b = init_guardian_core({"trust_file": "b.json"}, mode="audit")
+    assert a is not b
+    assert a.config["trust_file"] == "a.json"
+    assert b.config["trust_file"] == "b.json"
+    assert a.runtime_constructed is False and b.runtime_constructed is False
+    loaded = [n for n in sys.modules if n == "project_guardian" or n.startswith("project_guardian.")]
+    assert loaded == []
+
+
+def test_audit_malformed_partial_config_still_inert(forbid_activation):
+    desc = init_guardian_core({"ui_config": {}, "resource_limits": {}}, mode="audit")
+    assert desc.runtime_constructed is False
+    assert "ui_config" in desc.config
+
+
+def test_invalid_mode_rejected_before_activation(forbid_activation):
+    with pytest.raises(ValueError, match="mode must be"):
+        init_guardian_core(mode="inspect")  # type: ignore[arg-type]
+
+
+def test_operational_disable_flags_skip_ensure_monitoring():
+    """Caller disable of background services must remain disabled on operational path."""
+    fake = MagicMock()
+    fake.config = {"enable_background_services": False}
+    get_core = MagicMock(return_value=fake)
+    ensure = MagicMock(side_effect=_fail)
+    schedule = MagicMock(side_effect=_fail)
+    stubs = _install_fake_singleton(get_core=get_core, ensure=ensure, schedule=schedule)
+    _purge_project_guardian_modules()
+    with patch.dict(sys.modules, stubs):
+        result = init_guardian_core(
+            {"enable_background_services": False}, mode="operational"
+        )
+    assert result is fake
+    get_core.assert_called_once()
+    ensure.assert_not_called()
+    schedule.assert_not_called()


### PR DESCRIPTION
## Summary
Bounded safety repair for Issue #23 (`EREBUS-003A-001`) on top of the local-reconciliation runtime lineage.

This change adds an audit-safe bootstrap/descriptor path that does **not construct GuardianCore** and therefore does not activate operational behavior merely to inspect configuration/architecture.

Exact verified product commit: `79b6c64` on `cursor/guardian-23-audit-bootstrap`.

Independent verification:
- Vega: **PASS**
- Architecture review: **READY_FOR_INTEGRATION_REVIEW** (`codex/review-23-audit` @ `13ccdf8`)

## Delivered
- explicit audit vs operational bootstrap distinction
- pure `GuardianBootstrapAudit` descriptor
- public `describe_guardian_bootstrap`
- audit path avoids GuardianCore construction
- operational path explicitly passes `mode="operational"`
- background-service opt-out preserved
- adversarial tests covering monitoring, ElysiaLoop, prompt evolution, UI auto-start, live probes, socket/subprocess/thread activation and repeated audit initialization

## Important limitation
Issue #23 must remain **OPEN**.

This branch does **not** yet deliver true construct-without-activate semantics for direct `get_guardian_core` / `GuardianCore(...)` usage. Direct construction may still start active subsystems. The next bounded task is to move activation out of `GuardianCore.__init__` behind an explicit activation boundary and make core construction non-activating by default or otherwise provably inspection-safe.

The descriptor must not be treated as proof of live runtime wiring.

## Lineage
Base is the reconciliation snapshot branch `elysia-local-reconciliation-20260909-1657` at `4d9fceba`.
`79b6c64` is one commit ahead of that base.

## Gates
- DRAFT only
- DO NOT MERGE to `main`
- no provider activation
- no live network probes
- no deployment
- preserve Issue #23 as open until construct-without-activate is independently proven
- PR #25 / PR #26 restacking is a separate HUMAN_GOVERNANCE_REQUIRED decision

Refs #7, #18, #23.