### PR TITLE
Governance v2 trusted admission and deterministic migration

### DIFF
--- a/elysia_collective_seed/autopilot/contracts/GOVERNANCE_V2_ADMISSION.md
+++ b/elysia_collective_seed/autopilot/contracts/GOVERNANCE_V2_ADMISSION.md
@@ -85,7 +85,9 @@ must explicitly inherit governance objective/gate references or fail closed.
 
 `migrate_v1_to_v2` requires:
 
-1. an exact v1 object and independently pinned source digest;
+1. an object validated against the preserved
+   `checkpoint_snapshot.v1.schema.json` contract and an independently pinned
+   source digest;
 2. an explicit v1-to-v2 manifest;
 3. a target generation greater than the v1 revision and any trusted minimum;
 4. an exact trusted migration authority ID/generation from configuration outside
@@ -131,3 +133,132 @@ App/hook, atomic production mutation guard, deployment control, provider/runtime
 activation, or TaskLedger integration in this package. Tests demonstrate the
 normative evaluator only. Issue #23 remains gated and PR #34 remains preserved
 unauthorized evidence.
+
+## Two universes and the authoritative mutation boundary
+
+Source: independent Cursor reconnaissance supplied by the user on 2026-09-12.
+This addition incorporates that finding; it does not repeat the reconnaissance
+or assert that any operational call path has been verified as protected.
+
+The **GOVERNANCE UNIVERSE** contains schema, checkpoint evaluator, admission
+contracts, gate inheritance and tests, including TaskLedger / Issue-33 constructs
+on governance-oriented tips. The **OPERATIONAL UNIVERSE** contains actual
+mutation/execution paths, task queues, repo adapters, Guardian cycles, and local
+or external Git writes. Those paths can exist on lineages that do not contain or
+import the governance implementation. Git-history presence, a passing evaluator,
+or a governance-oriented branch does not join these universes.
+
+Normative principle:
+
+> No semantic or durable mutation path may infer authority merely because governance state exists elsewhere. The authoritative mutation boundary must consume a trusted admitted record and current effective gate state before mutation.
+
+Passing governance tests alone does not establish this property in production.
+An evaluator result, even `NO_MATCHING_BLOCK_NOT_AUTHORIZATION`, is not a mutation
+permit. Actual coverage requires an authoritative bridge on the executing
+operational lineage and evidence that every relevant route crosses that boundary.
+An import alone is insufficient. A gated objective and an unprotected path can
+coexist: the objective remains gated while the path is `NOT_ENFORCED`.
+
+## Operational mutation surfaces and required admission bindings
+
+All four surfaces below are concrete future enforcement/bypass surfaces from
+Cursor's findings. None is assumed to consult governance. In the absence of
+direct evidence of authoritative enforcement, each is `NOT_ENFORCED`.
+
+For **each** surface, the future boundary must obtain the complete trusted
+admission bundle below from a trusted source, bound to the exact attempted effect.
+These are bridge proof obligations, not claims that new fields or a production
+permit format have already been implemented in v2:
+
+| Required binding | What the admission record and trusted current state must supply |
+| --- | --- |
+| Admitted entity identity | Stable entity ID/kind, exact admission generation and authenticated authority ID/generation; bind the acting task and concrete operation/target to that entity. Worker labels cannot supply authority. |
+| Root/derived classification | Explicit trusted root decision and root evidence, or derived classification with existing admitted parents. Empty ancestry cannot create a root. |
+| Ancestry | All admitted parents and independently established repository/control-plane ancestry, including ports, queue sources and detached checkout identity as applicable. |
+| Governance lineage | Reviewed semantic descent across all parents, ports, restacks and recreated work, with inherited objective/gate references; Git disconnection cannot erase it. |
+| Objective | Trusted objective references inherited by union, bound to the proposed effect, including Issue #23 when applicable. Unknown equivalence fails closed. |
+| Action class | Authoritative classification of every intended effect before mutation; compound operations must cover every applicable class. A worker's test/docs label cannot narrow it. |
+| Applicable gate generation | Effective inherited gate IDs and their exact current generations from trusted state, including applicable scope/actions and release state. A prior admission cannot freeze older gate state. |
+| Trusted snapshot/generation | Independently trusted current snapshot digest and monotonic generation, authority-registry generation, and durable rollback high-water mark; recheck freshness at the mutation boundary. |
+| Human-release evidence when required | Authenticated human authority, release provenance, objective/action/gate scope and exact gate generation, validated against current state. A worker assertion or tests cannot release a gate. Validation is currently `UNAVAILABLE`, so required releases remain blocked. |
+
+The following per-surface bindings specialize **all nine** requirements above;
+they are not substitutes for them. Action examples are minimum candidate classes,
+not an exhaustive preclassification of uninspected runtime behavior.
+
+| Surface | Entity, ancestry and effect that the trusted bundle must bind | Objective/action and gate application | Current classification |
+| --- | --- | --- | --- |
+| `mutation_engine._direct_apply_mutation` | Admitted mutation request derived from its submitting task/proposal; exact target checkout/content generation and intended change. A direct call cannot omit its parent or mint a root. | Resolve semantic objective/lineage before apply; classify `semantic_code_write` and/or other applicable durable writes. Consume current inherited gates and generation-scoped release evidence immediately before the effect. | `NOT_ENFORCED` |
+| `implementer/repo_adapter` | Admitted repository operation derived from the implementing task and mutation request; exact repository, target state and local/external destination. Preserve governance descent through ports/restacks regardless of branch or detached SHA. | Classify applicable `repo_write`, `integration`, `merge`, `external_write`, and semantic effects; bind each effect to current objective gates and required releases. Direct adapter invocation must require the same bundle. | `NOT_ENFORCED` |
+| `self_task_queue` | Admitted queue entry/operation derived from the producer task and its full ancestry; persist admission identity/generation through enqueue, update, retry and dequeue/execution. Queue persistence itself needs classification. | Classify durable queue changes and the eventual execution effects under inherited objectives. Re-read current gates on execution/retry; an enqueue-time snapshot or queue-generated task ID grants no authority. | `NOT_ENFORCED` |
+| `guardian_cursor_cycle` | Admitted cycle operation and derived child work tied to originating task(s), inputs and intended output targets; retain ancestry/governance lineage across cycle, worker and restart boundaries. | Classify dispatch, durable cycle updates and each downstream semantic/repository/external effect as applicable. Reconsume current gates at each mutation boundary; a successful cycle or worker output cannot supply release evidence. | `NOT_ENFORCED` |
+
+## Required governance-to-runtime bridge (future, not implemented)
+
+The bridge MUST guarantee all of the following before enforcement can be claimed:
+
+1. **One authoritative admission format.** Runtime paths consume the same
+   versioned, authenticated admitted record, resolved outside worker control and
+   bound to the exact requested effect. Caller-specific permissive formats or
+   worker-supplied authority registries are not alternate admission mechanisms.
+2. **One trusted current gate snapshot.** All boundaries resolve effective gates
+   from the authoritative state source, with independently pinned digest,
+   snapshot/gate/authority generations and a defined freshness protocol.
+3. **Objective/action classification before mutation.** Resolve all applicable
+   objectives and action classes, and ancestry/governance-lineage inheritance
+   across every parent, before any semantic or durable effect. Unknown, missing,
+   contradictory or unavailable classification/state fails closed.
+4. **Atomic check + mutation or equivalent transactional protection.** Bind the
+   admission, exact effect/target state and current gate generation in the commit
+   protocol. A concurrent gate change invalidates stale decisions. A local check
+   followed by an unguarded write is insufficient; external effects need an
+   equivalent generation-fenced protocol at the authoritative external boundary.
+5. **No worker-controlled root creation.** Only the trusted admission authority
+   may admit roots. Task/session/provider changes and empty parents cannot reset
+   inheritance.
+6. **No branch-name or detached-SHA escape.** Bind trusted repository identity and
+   state plus semantic governance lineage. Renames, rebases, ports, restacks,
+   cherry-picks and detached execution cannot subtract inherited gates.
+7. **No direct adapter bypass and no queue/cycle bypass.** Every relevant entry
+   point and downstream write must cross the authoritative boundary, including
+   direct calls, retries, resumed work and local/external Git writes. Protecting
+   one wrapper does not establish complete coverage.
+8. **Restart-safe state and generation rollback protection.** Persist admissions,
+   lineage, gate state, trusted generation high-water marks and effect receipts
+   transactionally outside worker control. Recovery cannot restore older trusted
+   state or replay a stale authorization; retries must revalidate current gates
+   and avoid duplicate effects. Unavailable recovery evidence fails closed.
+9. **Validated release and output provenance.** A required human release must be
+   authenticated and bound to the effective gate generation and intended scope.
+   Record an authoritative effect receipt tying output to the admitted operation
+   and checked generations. Output existence, test success or a worker's receipt
+   alone must never be accepted as authorized progress.
+
+## Cross-universe acceptance scenarios (specification only)
+
+These are normative scenarios for future bridge verification, not executed
+runtime tests. They require no imports or invocation of the unprotected paths
+in the current specification work. Repeat every scenario for each of the four
+surfaces above and for applicable local/external effects.
+
+Base setup: trusted governance state on lineage G gates an objective (Issue #23
+is a concrete example). Operational lineage O contains the selected mutation
+path but does not contain/import the governance implementation. No authoritative
+bridge exists. A worker attempts mutation on O under that objective.
+
+| Scenario | Expected normative result |
+| --- | --- |
+| Base setup, regardless of whether the worker produces output | Path classification is `NOT_ENFORCED`; cross-universe enforcement is `NOT_IMPLEMENTED`. Do not report an actual blocked mutation without runtime evidence. The objective remains gated. |
+| Output exists and passes operational tests; governance tests also pass on G | Output remains unauthorized evidence, never authorized progress or a gate release. Test success does not demonstrate that O consulted G. |
+| Governance code is later copied/imported on O, but no authoritative check guards the effect | Still `NOT_ENFORCED`; availability/import is not boundary enforcement. |
+| Worker changes branch name, uses detached SHA, recreates a patch, or claims a new root | Still `NOT_ENFORCED` without a bridge, and no normative authority is gained. Future bridge must preserve inherited gates and reject fabricated roots. |
+| Worker calls the adapter directly or resumes queued/cycle work | Still `NOT_ENFORCED` without coverage evidence. A future wrapper-only bridge cannot authorize these bypass routes. |
+| Future bridge sees missing admission, unknown objective/action, stale snapshot, generation rollback or unavailable required release validation | Required behavior is fail-closed before effects. This is a future acceptance obligation, not evidence of a present runtime block. |
+| Future gate changes between check and write, or process restarts/retries | Required behavior is transactional rejection/revalidation of stale authority without duplicate effects or rollback; test the interleaving at the actual boundary. |
+
+Future integration tests must observe the real mutation boundary and its effects,
+not merely stub an evaluator that returns a desired result. Even demonstrated
+coverage of one surface does not change the other surfaces' classifications.
+Current cross-universe enforcement remains `NOT_IMPLEMENTED`.
+
+Issue #23 remains: `GATED — NO SEMANTIC WORK AUTHORIZED`.

--- a/elysia_collective_seed/autopilot/contracts/GOVERNANCE_V2_ADMISSION.md
+++ b/elysia_collective_seed/autopilot/contracts/GOVERNANCE_V2_ADMISSION.md
@@ -1,0 +1,133 @@
+# Governance snapshot v2 and trusted admission contract
+
+Status: `SPECIFICATION_AND_TEST_ONLY`. This document and its executable reference
+model define proof obligations for a future service. They do not authenticate an
+authority, read GitHub, intercept Git, mutate TaskLedger, or permit an action.
+
+## Version strategy
+
+Snapshot v2 is a breaking replacement for the draft v1 shape. A consumer accepts
+only integer `schema_version: 2`; missing, boolean, string, older, and forward
+versions fail closed. `snapshot_generation` is a monotonically increasing state
+generation. A consumer with a previously trusted generation rejects a lower one.
+The complete snapshot digest must be pinned by an independently trusted current
+state source; hashes supplied alongside worker-controlled content prove nothing.
+
+V1 is supported only as explicit migration input. No runtime consumer treats v1
+as v2. In particular, `parents=[]` never implies root status.
+
+## Trusted admission record
+
+`admissions` is separate from the proposed worker payload. Each record binds:
+
+- stable entity ID and kind;
+- explicitly admitted root or derived status;
+- parent IDs;
+- repository lineage references (Git facts such as branch/SHA/parents);
+- governance lineage references (semantic ports/restacks across Git history);
+- objective references;
+- one or more authoritative action classes;
+- admission generation, authority ID/generation, source, evidence and time;
+- explicitly inherited gate references.
+
+The authority must resolve to the snapshot's independently configured admission
+authority registry at the exact generation. Schema-valid authority strings are
+still only a normative representation. A production service must authenticate
+and control that registry outside worker credentials.
+
+`evaluate_admitted` accepts entity/action classification from the future trusted
+admission boundary and ignores descriptive `worker_proposal` metadata. The action
+must be present in the stored admission. A worker cannot downgrade
+`semantic_code_write` to `test_only` or replace the objective, ancestry, or root
+status in its proposal. Missing, contradictory, or unknown admission data blocks.
+
+## Root admission
+
+Root creation is privileged classification. It requires a record admitted by a
+known trusted control-plane authority and evidence that establishes an objective
+root. Zero parents, a new branch/task/session/provider, a detached checkout, or a
+new objective string is insufficient. Derived records require existing parents.
+Ambiguity remains blocked until trusted review produces a new admission record.
+
+The normative model cannot prove that its configured authority is actually
+trusted. Production must keep authority configuration outside worker control.
+
+## Objective and action classification
+
+Objectives are durable references, inherited by union across every parent.
+Renaming work does not subtract them. Expansion adds references. Reclassification
+requires a new, higher-generation trusted admission with evidence; it cannot
+rewrite history. Ambiguous semantic equivalence routes to human governance rather
+than accepting an unrelated label. General model output may be evidence but is
+not unquestioned classification authority.
+
+V2 action classes are `static_read`, `test_only`, `docs_only`,
+`schema_spec_write`, `semantic_code_write`, `repo_write`, `integration`, `merge`,
+`deploy`, `external_write`, `permission_change`, and `private_data_access`.
+Governance gates must include every consequential class from semantic code write
+through private-data access. Static/test/docs/spec labels do not override stored
+classification. A no-match result remains `NO_MATCHING_BLOCK_NOT_AUTHORIZATION`.
+
+## Repository ancestry and governance lineage
+
+Repository lineage records observable Git/control-plane facts: commit parents,
+branch tips, pull-request refs, detached checkouts, and merge parents. Governance
+lineage records semantic descent that Git ancestry cannot prove, including
+cherry-picks, ports, restacks, recreated patches, and preservation branches.
+Either kind can match a gate; both union transitively through all parents.
+
+The future admission service must derive repository lineage from trusted
+repository state and governance lineage from reviewed provenance/evidence. A
+worker cannot declare either authoritative. Semantic ports without Git ancestry
+must explicitly inherit governance objective/gate references or fail closed.
+
+## Deterministic v1 → v2 migration
+
+`migrate_v1_to_v2` requires:
+
+1. an exact v1 object and independently pinned source digest;
+2. an explicit v1-to-v2 manifest;
+3. a target generation greater than the v1 revision and any trusted minimum;
+4. an exact trusted migration authority ID/generation from configuration outside
+   the manifest;
+5. exactly one classification decision for every v1 entity;
+6. exact preservation of parents, objectives and gate references;
+7. preservation (and optional expansion) of repository lineage;
+8. nonempty governance lineage and admission evidence;
+9. explicit root-admission evidence for every parentless root;
+10. durable source/manifest digests, authority, time and evidence in migration
+    provenance.
+
+Derived records require their known parent list. Parentless records are ambiguous
+until the manifest explicitly classifies them as roots with trusted evidence.
+Active gates are copied. Old action names are mapped conservatively and all v2
+consequential actions are added, so migration cannot narrow a gate. Stored
+`released` assertions remain present and effective because release validation is
+still `UNAVAILABLE`.
+
+The reference function is deterministic for identical source, manifest, pin and
+authority configuration. It performs no file/database writes. A production
+migration must additionally preserve append-only generations transactionally,
+prevent concurrent rollback, and persist an immutable audit record.
+
+## Fail-closed conditions
+
+Unsupported version; stale source digest; generation rollback; absent or unknown
+authority; incomplete, duplicate, missing or conflicting admissions; fabricated
+parents; lost objective, lineage, gate, or active-gate data; unknown action; action
+downgrade; ambiguous root; malformed record; stale current-state pin; and
+unvalidated release all block. A valid unrelated admission can report no matching
+gate, but that report grants no authority.
+
+## Non-implementation boundaries
+
+`production_enforcement=NOT_IMPLEMENTED`.
+`human_trust_anchor=UNRESOLVED`.
+`external_write_enforcement=NOT_ENFORCED`.
+`release_validation=UNAVAILABLE`.
+
+There is no live repository service, cryptographic human authentication, GitHub
+App/hook, atomic production mutation guard, deployment control, provider/runtime
+activation, or TaskLedger integration in this package. Tests demonstrate the
+normative evaluator only. Issue #23 remains gated and PR #34 remains preserved
+unauthorized evidence.

--- a/elysia_collective_seed/autopilot/contracts/README.md
+++ b/elysia_collective_seed/autopilot/contracts/README.md
@@ -1,6 +1,6 @@
 # Checkpoint governance admission contract
 
-Status: executable normative specification for GitHub Issues #29/#30/#31.
+Status: executable normative specification for GitHub Issues #29/#30/#31/#33.
 This package is not connected to TaskLedger, the scheduler, Guardian, Codex,
 Cursor, Git, or a repository policy service. Passing its tests does not close
 any of those issues or release the Issue #23 gate.
@@ -21,7 +21,10 @@ contract without replacing, importing, modifying, or certifying that work.
 ## Inputs and decisions
 
 `checkpoint_snapshot.schema.json` defines a **complete** snapshot of gates and
-admitted entities. Gate scope identifies both objectives and branch/PR/SHA
+trusted admission records under `schema_version: 2`. See
+`GOVERNANCE_V2_ADMISSION.md` for versioning, migration, root authority, objective
+and action classification, and the Git-ancestry/governance-lineage distinction.
+Gate scope identifies both objectives and branch/PR/SHA
 lineages. Entity parent links represent task subdivision and restacking; all
 ancestor objective references, lineage references, and explicit gate references
 are unioned. Matching either objective or lineage, or an explicit inherited gate

--- a/elysia_collective_seed/autopilot/contracts/admission.py
+++ b/elysia_collective_seed/autopilot/contracts/admission.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 from copy import deepcopy
 import hashlib
 import json
+from pathlib import Path
 from typing import Mapping
 
-from .checkpoint_reference import VALIDATOR, Decision, evaluate, snapshot_digest
+from jsonschema import Draft202012Validator
+
+from .checkpoint_reference import SCHEMA, VALIDATOR, Decision, evaluate, snapshot_digest
 
 
 class AdmissionError(ValueError):
@@ -22,6 +25,11 @@ MANDATORY_GATED_ACTIONS = (
     "semantic_code_write", "repo_write", "integration", "merge", "deploy",
     "external_write", "permission_change", "private_data_access",
 )
+V1_SCHEMA = json.loads(Path(__file__).with_name("checkpoint_snapshot.v1.schema.json").read_text(encoding="utf-8"))
+V1_VALIDATOR = Draft202012Validator(V1_SCHEMA)
+AUTHORITY_VALIDATOR = Draft202012Validator({
+    "$schema": SCHEMA["$schema"], "$defs": SCHEMA["$defs"], "$ref": "#/$defs/authority",
+})
 
 
 def _digest(value) -> str:
@@ -95,6 +103,8 @@ def _migrate_v1_to_v2(legacy, manifest, *, trusted_source_digest,
     required_legacy = {"schema_version", "revision", "source_refs", "gates", "entities"}
     if set(legacy) != required_legacy or type(legacy["revision"]) is not int or legacy["revision"] < 1:
         raise AdmissionError("invalid_v1_snapshot")
+    if not V1_VALIDATOR.is_valid(legacy):
+        raise AdmissionError("invalid_v1_snapshot")
     if (not isinstance(manifest, dict)
             or type(manifest.get("from_schema_version")) is not int
             or type(manifest.get("to_schema_version")) is not int
@@ -110,7 +120,9 @@ def _migrate_v1_to_v2(legacy, manifest, *, trusted_source_digest,
         raise AdmissionError("missing_migration_authority")
     if (not isinstance(trusted_authorities, (list, tuple))
             or any(not isinstance(a, Mapping) for a in trusted_authorities)):
-        raise AdmissionError("invalid_trusted_authorities")
+        raise AdmissionError("invalid_trusted_authority_registry")
+    if any(not AUTHORITY_VALIDATOR.is_valid(dict(a)) for a in trusted_authorities):
+        raise AdmissionError("invalid_trusted_authority_registry")
     trusted = {(a.get("authority_id"), a.get("authority_generation")): a
                for a in trusted_authorities}
     if len(trusted) != len(trusted_authorities):
@@ -144,7 +156,11 @@ def _migrate_v1_to_v2(legacy, manifest, *, trusted_source_digest,
         if decision.get("governance_gate_refs") != source.get("governance_gate_refs"):
             raise AdmissionError("migration_cannot_drop_gate_refs")
         if decision.get("ancestry_kind") == "root":
-            if source.get("parent_refs") or not isinstance(root_evidence, list) or not root_evidence:
+            if (source.get("parent_refs") or not isinstance(root_evidence, list)
+                    or not root_evidence
+                    or any(type(ref) is not str or not ref.strip()
+                           or ref != ref.strip() for ref in root_evidence)
+                    or len(set(root_evidence)) != len(root_evidence)):
                 raise AdmissionError("root_requires_explicit_migration_evidence")
         elif decision.get("ancestry_kind") == "derived":
             if not source.get("parent_refs"):

--- a/elysia_collective_seed/autopilot/contracts/admission.py
+++ b/elysia_collective_seed/autopilot/contracts/admission.py
@@ -31,7 +31,9 @@ def _digest(value) -> str:
 
 def validate_snapshot_version(snapshot, *, minimum_generation=None) -> None:
     """Reject unsupported versions and generation rollback before evaluation."""
-    if not isinstance(snapshot, dict) or snapshot.get("schema_version") != 2:
+    if (not isinstance(snapshot, dict)
+            or type(snapshot.get("schema_version")) is not int
+            or snapshot.get("schema_version") != 2):
         raise AdmissionError("unsupported_schema_version")
     if minimum_generation is not None and (
         type(minimum_generation) is not int
@@ -68,14 +70,20 @@ def migrate_v1_to_v2(legacy, manifest, *, trusted_source_digest,
     this function is not authentication; callers must supply independently trusted
     authority configuration and the current source digest.
     """
-    if not isinstance(legacy, dict) or legacy.get("schema_version") != 1:
+    if (not isinstance(legacy, dict)
+            or type(legacy.get("schema_version")) is not int
+            or legacy.get("schema_version") != 1):
         raise AdmissionError("source_must_be_v1")
     if snapshot_digest(legacy) != trusted_source_digest:
         raise AdmissionError("stale_or_untrusted_source_digest")
     required_legacy = {"schema_version", "revision", "source_refs", "gates", "entities"}
     if set(legacy) != required_legacy or type(legacy["revision"]) is not int or legacy["revision"] < 1:
         raise AdmissionError("invalid_v1_snapshot")
-    if not isinstance(manifest, dict) or manifest.get("from_schema_version") != 1 or manifest.get("to_schema_version") != 2:
+    if (not isinstance(manifest, dict)
+            or type(manifest.get("from_schema_version")) is not int
+            or type(manifest.get("to_schema_version")) is not int
+            or manifest.get("from_schema_version") != 1
+            or manifest.get("to_schema_version") != 2):
         raise AdmissionError("explicit_v1_to_v2_manifest_required")
     generation = manifest.get("target_snapshot_generation")
     if type(generation) is not int or generation <= max(legacy["revision"], minimum_target_generation - 1):
@@ -84,8 +92,13 @@ def migrate_v1_to_v2(legacy, manifest, *, trusted_source_digest,
     authority_ref = manifest.get("migration_authority")
     if not isinstance(authority_ref, dict):
         raise AdmissionError("missing_migration_authority")
+    if (not isinstance(trusted_authorities, (list, tuple))
+            or any(not isinstance(a, Mapping) for a in trusted_authorities)):
+        raise AdmissionError("invalid_trusted_authorities")
     trusted = {(a.get("authority_id"), a.get("authority_generation")): a
-               for a in trusted_authorities if isinstance(a, Mapping)}
+               for a in trusted_authorities}
+    if len(trusted) != len(trusted_authorities):
+        raise AdmissionError("duplicate_trusted_authority")
     key = (authority_ref.get("authority_id"), authority_ref.get("authority_generation"))
     authority = trusted.get(key)
     if not authority or authority.get("authority_kind") != "trusted_migration_control_plane":
@@ -124,12 +137,15 @@ def migrate_v1_to_v2(legacy, manifest, *, trusted_source_digest,
             raise AdmissionError("ancestry_classification_required")
         admissions.append(decision)
 
-    gates = deepcopy(legacy["gates"])
-    for gate in gates:
-        mapped = [ACTION_MIGRATION.get(a, a) for a in gate["blocked_actions"]]
-        gate["blocked_actions"] = list(dict.fromkeys(mapped + list(MANDATORY_GATED_ACTIONS)))
-        if gate.get("release"):
-            gate["release"]["actions"] = list(dict.fromkeys(ACTION_MIGRATION.get(a, a) for a in gate["release"]["actions"]))
+    try:
+        gates = deepcopy(legacy["gates"])
+        for gate in gates:
+            mapped = [ACTION_MIGRATION.get(a, a) for a in gate["blocked_actions"]]
+            gate["blocked_actions"] = list(dict.fromkeys(mapped + list(MANDATORY_GATED_ACTIONS)))
+            if gate.get("release"):
+                gate["release"]["actions"] = list(dict.fromkeys(ACTION_MIGRATION.get(a, a) for a in gate["release"]["actions"]))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise AdmissionError("invalid_v1_snapshot") from exc
 
     migrated_at = manifest.get("migrated_at")
     evidence = manifest.get("evidence_refs")
@@ -152,4 +168,12 @@ def migrate_v1_to_v2(legacy, manifest, *, trusted_source_digest,
         },
     }
     validate_snapshot_version(target, minimum_generation=minimum_target_generation)
+    probe = target["admissions"][0]
+    semantic = evaluate(
+        target,
+        {"entity_id": probe["entity_id"], "action": probe["action_classes"][0]},
+        trusted_current_digest=snapshot_digest(target),
+    )
+    if semantic.disposition == "BLOCKED_INVALID_STATE":
+        raise AdmissionError(f"invalid_v2_semantics:{semantic.reason}")
     return target

--- a/elysia_collective_seed/autopilot/contracts/admission.py
+++ b/elysia_collective_seed/autopilot/contracts/admission.py
@@ -64,6 +64,22 @@ def evaluate_admitted(snapshot, entity_id, authoritative_action, *,
 
 def migrate_v1_to_v2(legacy, manifest, *, trusted_source_digest,
                      trusted_authorities, minimum_target_generation=1):
+    """Fail-closed public boundary for deterministic v1-to-v2 migration."""
+    try:
+        return _migrate_v1_to_v2(
+            legacy, manifest,
+            trusted_source_digest=trusted_source_digest,
+            trusted_authorities=trusted_authorities,
+            minimum_target_generation=minimum_target_generation,
+        )
+    except AdmissionError:
+        raise
+    except (KeyError, TypeError, ValueError, RecursionError) as exc:
+        raise AdmissionError("malformed_migration_input") from exc
+
+
+def _migrate_v1_to_v2(legacy, manifest, *, trusted_source_digest,
+                      trusted_authorities, minimum_target_generation=1):
     """Deterministically migrate only with explicit classification evidence.
 
     This models what a trusted migration service must prove. Passing a mapping to

--- a/elysia_collective_seed/autopilot/contracts/admission.py
+++ b/elysia_collective_seed/autopilot/contracts/admission.py
@@ -1,0 +1,155 @@
+"""Normative v2 admission and migration model; no production trust service."""
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import json
+from typing import Mapping
+
+from .checkpoint_reference import VALIDATOR, Decision, evaluate, snapshot_digest
+
+
+class AdmissionError(ValueError):
+    """A migration or admission input cannot be trusted by this model."""
+
+
+ACTION_MIGRATION = {
+    "claim": "repo_write", "semantic_write": "semantic_code_write",
+    "read": "static_read", "static_analysis": "static_read",
+    "specification": "schema_spec_write", "test_design": "test_only",
+}
+MANDATORY_GATED_ACTIONS = (
+    "semantic_code_write", "repo_write", "integration", "merge", "deploy",
+    "external_write", "permission_change", "private_data_access",
+)
+
+
+def _digest(value) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def validate_snapshot_version(snapshot, *, minimum_generation=None) -> None:
+    """Reject unsupported versions and generation rollback before evaluation."""
+    if not isinstance(snapshot, dict) or snapshot.get("schema_version") != 2:
+        raise AdmissionError("unsupported_schema_version")
+    if minimum_generation is not None and (
+        type(minimum_generation) is not int
+        or snapshot.get("snapshot_generation", 0) < minimum_generation
+    ):
+        raise AdmissionError("snapshot_generation_rollback")
+    if not VALIDATOR.is_valid(snapshot):
+        raise AdmissionError("invalid_v2_snapshot")
+
+
+def evaluate_admitted(snapshot, entity_id, authoritative_action, *,
+                       trusted_current_digest, worker_proposal=None,
+                       minimum_generation=None) -> Decision:
+    """Evaluate trusted admission; descriptive worker metadata grants nothing."""
+    try:
+        validate_snapshot_version(snapshot, minimum_generation=minimum_generation)
+    except AdmissionError as exc:
+        return Decision("BLOCKED_INVALID_STATE", reason=str(exc))
+    # worker_proposal is retained solely to make the trust separation explicit.
+    # Production must derive entity/action from trusted repository/control-plane
+    # evidence and pass those values as the authoritative parameters.
+    del worker_proposal
+    return evaluate(
+        snapshot, {"entity_id": entity_id, "action": authoritative_action},
+        trusted_current_digest=trusted_current_digest,
+    )
+
+
+def migrate_v1_to_v2(legacy, manifest, *, trusted_source_digest,
+                     trusted_authorities, minimum_target_generation=1):
+    """Deterministically migrate only with explicit classification evidence.
+
+    This models what a trusted migration service must prove. Passing a mapping to
+    this function is not authentication; callers must supply independently trusted
+    authority configuration and the current source digest.
+    """
+    if not isinstance(legacy, dict) or legacy.get("schema_version") != 1:
+        raise AdmissionError("source_must_be_v1")
+    if snapshot_digest(legacy) != trusted_source_digest:
+        raise AdmissionError("stale_or_untrusted_source_digest")
+    required_legacy = {"schema_version", "revision", "source_refs", "gates", "entities"}
+    if set(legacy) != required_legacy or type(legacy["revision"]) is not int or legacy["revision"] < 1:
+        raise AdmissionError("invalid_v1_snapshot")
+    if not isinstance(manifest, dict) or manifest.get("from_schema_version") != 1 or manifest.get("to_schema_version") != 2:
+        raise AdmissionError("explicit_v1_to_v2_manifest_required")
+    generation = manifest.get("target_snapshot_generation")
+    if type(generation) is not int or generation <= max(legacy["revision"], minimum_target_generation - 1):
+        raise AdmissionError("target_generation_not_monotonic")
+
+    authority_ref = manifest.get("migration_authority")
+    if not isinstance(authority_ref, dict):
+        raise AdmissionError("missing_migration_authority")
+    trusted = {(a.get("authority_id"), a.get("authority_generation")): a
+               for a in trusted_authorities if isinstance(a, Mapping)}
+    key = (authority_ref.get("authority_id"), authority_ref.get("authority_generation"))
+    authority = trusted.get(key)
+    if not authority or authority.get("authority_kind") != "trusted_migration_control_plane":
+        raise AdmissionError("unknown_migration_authority")
+
+    legacy_entities = legacy["entities"]
+    if not isinstance(legacy_entities, list) or any(not isinstance(e, dict) for e in legacy_entities):
+        raise AdmissionError("invalid_v1_entities")
+    old = {e.get("entity_id"): e for e in legacy_entities}
+    decisions = manifest.get("admissions")
+    if not isinstance(decisions, list) or any(not isinstance(e, dict) for e in decisions):
+        raise AdmissionError("missing_admission_decisions")
+    new = {e.get("entity_id"): e for e in decisions}
+    if len(old) != len(legacy_entities) or len(new) != len(decisions) or set(old) != set(new):
+        raise AdmissionError("migration_must_classify_every_entity_exactly_once")
+
+    admissions = []
+    for entity_id, source in old.items():
+        decision = deepcopy(new[entity_id])
+        root_evidence = decision.pop("root_admission_evidence", None)
+        if decision.get("parent_refs") != source.get("parent_refs"):
+            raise AdmissionError("migration_cannot_rewrite_ancestry")
+        if decision.get("objective_refs") != source.get("objective_refs"):
+            raise AdmissionError("migration_cannot_rewrite_objectives")
+        if not set(source.get("lineage_refs", [])).issubset(decision.get("repository_lineage_refs", [])):
+            raise AdmissionError("migration_cannot_drop_repository_lineage")
+        if decision.get("governance_gate_refs") != source.get("governance_gate_refs"):
+            raise AdmissionError("migration_cannot_drop_gate_refs")
+        if decision.get("ancestry_kind") == "root":
+            if source.get("parent_refs") or not isinstance(root_evidence, list) or not root_evidence:
+                raise AdmissionError("root_requires_explicit_migration_evidence")
+        elif decision.get("ancestry_kind") == "derived":
+            if not source.get("parent_refs"):
+                raise AdmissionError("empty_parents_are_ambiguous_not_derived")
+        else:
+            raise AdmissionError("ancestry_classification_required")
+        admissions.append(decision)
+
+    gates = deepcopy(legacy["gates"])
+    for gate in gates:
+        mapped = [ACTION_MIGRATION.get(a, a) for a in gate["blocked_actions"]]
+        gate["blocked_actions"] = list(dict.fromkeys(mapped + list(MANDATORY_GATED_ACTIONS)))
+        if gate.get("release"):
+            gate["release"]["actions"] = list(dict.fromkeys(ACTION_MIGRATION.get(a, a) for a in gate["release"]["actions"]))
+
+    migrated_at = manifest.get("migrated_at")
+    evidence = manifest.get("evidence_refs")
+    if not isinstance(migrated_at, str) or not isinstance(evidence, list) or not evidence:
+        raise AdmissionError("migration_provenance_required")
+    target = {
+        "schema_version": 2,
+        "snapshot_generation": generation,
+        "source_refs": deepcopy(legacy["source_refs"]),
+        "admission_authorities": [deepcopy(authority)],
+        "gates": gates,
+        "admissions": admissions,
+        "migration_provenance": {
+            "from_schema_version": 1,
+            "source_snapshot_digest": trusted_source_digest,
+            "migration_manifest_digest": _digest(manifest),
+            "migrated_by": deepcopy(authority_ref),
+            "migrated_at": migrated_at,
+            "evidence_refs": deepcopy(evidence),
+        },
+    }
+    validate_snapshot_version(target, minimum_generation=minimum_target_generation)
+    return target

--- a/elysia_collective_seed/autopilot/contracts/checkpoint_reference.py
+++ b/elysia_collective_seed/autopilot/contracts/checkpoint_reference.py
@@ -19,16 +19,32 @@ from jsonschema import Draft202012Validator, FormatChecker
 SCHEMA = json.loads(Path(__file__).with_name("checkpoint_snapshot.schema.json").read_text(encoding="utf-8"))
 FORMAT_CHECKER = FormatChecker()
 RFC3339 = re.compile(
-    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+    r"^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})T"
+    r"(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})"
+    r"(?:\.\d+)?(?P<zone>Z|[+-](?P<zone_hour>\d{2}):(?P<zone_minute>\d{2}))$"
 )
 
 
 @FORMAT_CHECKER.checks("date-time", raises=(TypeError, ValueError))
 def _is_rfc3339_datetime(value):
-    if not isinstance(value, str) or RFC3339.fullmatch(value) is None:
+    if not isinstance(value, str):
         return False
-    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    return parsed.tzinfo is not None
+    match = RFC3339.fullmatch(value)
+    if match is None:
+        return False
+    parts = {name: int(match.group(name)) for name in
+             ("year", "month", "day", "hour", "minute", "second")}
+    if parts["second"] > 60 or parts["hour"] > 23 or parts["minute"] > 59:
+        return False
+    if match.group("zone") != "Z" and (
+            int(match.group("zone_hour")) > 23
+            or int(match.group("zone_minute")) > 59):
+        return False
+    # datetime validates calendar dates. RFC 3339 permits the leap-second value
+    # 60, so use 59 solely for calendar validation after checking the bound.
+    datetime(parts["year"], parts["month"], parts["day"], parts["hour"],
+             parts["minute"], min(parts["second"], 59))
+    return True
 
 
 VALIDATOR = Draft202012Validator(SCHEMA, format_checker=FORMAT_CHECKER)

--- a/elysia_collective_seed/autopilot/contracts/checkpoint_reference.py
+++ b/elysia_collective_seed/autopilot/contracts/checkpoint_reference.py
@@ -19,9 +19,9 @@ from jsonschema import Draft202012Validator, FormatChecker
 SCHEMA = json.loads(Path(__file__).with_name("checkpoint_snapshot.schema.json").read_text(encoding="utf-8"))
 FORMAT_CHECKER = FormatChecker()
 RFC3339 = re.compile(
-    r"^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})T"
-    r"(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})"
-    r"(?:\.\d+)?(?P<zone>Z|[+-](?P<zone_hour>\d{2}):(?P<zone_minute>\d{2}))$"
+    r"^(?P<year>[0-9]{4})-(?P<month>[0-9]{2})-(?P<day>[0-9]{2})T"
+    r"(?P<hour>[0-9]{2}):(?P<minute>[0-9]{2}):(?P<second>[0-9]{2})"
+    r"(?:\.[0-9]+)?(?P<zone>Z|[+-](?P<zone_hour>[0-9]{2}):(?P<zone_minute>[0-9]{2}))$"
 )
 
 

--- a/elysia_collective_seed/autopilot/contracts/checkpoint_reference.py
+++ b/elysia_collective_seed/autopilot/contracts/checkpoint_reference.py
@@ -53,9 +53,11 @@ no human-controlled release trust anchor has been selected.
                 or type(proposal["entity_id"]) is not str
                 or type(proposal["action"]) is not str or proposal["action"] not in ACTIONS):
             return invalid("proposal_schema")
-        nodes = {n["entity_id"]: n for n in snapshot["entities"]}
+        nodes = {n["entity_id"]: n for n in snapshot["admissions"]}
         gates = {g["gate_id"]: g for g in snapshot["gates"]}
-        if len(nodes) != len(snapshot["entities"]) or len(gates) != len(snapshot["gates"]):
+        authorities = {(a["authority_id"], a["authority_generation"]): a for a in snapshot["admission_authorities"]}
+        if (len(nodes) != len(snapshot["admissions"]) or len(gates) != len(snapshot["gates"])
+                or len(authorities) != len(snapshot["admission_authorities"])):
             return invalid("duplicate_identity")
         if proposal["entity_id"] not in nodes:
             return invalid("unknown_entity")
@@ -68,12 +70,16 @@ no human-controlled release trust anchor has been selected.
             progressed = False
             for key in sorted(pending):
                 node = nodes[key]
+                authority = node["admitted_by"]
+                if (authority["authority_id"], authority["authority_generation"]) not in authorities:
+                    return invalid("unknown_admission_authority")
                 if any(p not in nodes for p in node["parent_refs"]):
                     return invalid("missing_parent")
                 if any(p not in scopes for p in node["parent_refs"]):
                     continue
-                objectives, lineages, refs = (set(node[k]) for k in
-                    ("objective_refs", "lineage_refs", "governance_gate_refs"))
+                objectives = set(node["objective_refs"])
+                lineages = set(node["repository_lineage_refs"]) | set(node["governance_lineage_refs"])
+                refs = set(node["governance_gate_refs"])
                 for parent in node["parent_refs"]:
                     for target, inherited in zip((objectives, lineages, refs), scopes[parent]):
                         target.update(inherited)
@@ -86,6 +92,8 @@ no human-controlled release trust anchor has been selected.
                 return invalid("ancestry_cycle")
 
         objectives, lineages, refs = scopes[proposal["entity_id"]]
+        if proposal["action"] not in nodes[proposal["entity_id"]]["action_classes"]:
+            return invalid("action_not_admitted")
         applicable = [g for g in gates.values() if
             g["gate_id"] in refs or objectives.intersection(g["scope"]["objective_refs"])
             or lineages.intersection(g["scope"]["lineage_refs"])]

--- a/elysia_collective_seed/autopilot/contracts/checkpoint_reference.py
+++ b/elysia_collective_seed/autopilot/contracts/checkpoint_reference.py
@@ -7,15 +7,31 @@ No result from this module grants permission to execute an action.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 import hashlib
 import json
 from pathlib import Path
+import re
 
-from jsonschema import Draft202012Validator
+from jsonschema import Draft202012Validator, FormatChecker
 
 
 SCHEMA = json.loads(Path(__file__).with_name("checkpoint_snapshot.schema.json").read_text(encoding="utf-8"))
-VALIDATOR = Draft202012Validator(SCHEMA)
+FORMAT_CHECKER = FormatChecker()
+RFC3339 = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+@FORMAT_CHECKER.checks("date-time", raises=(TypeError, ValueError))
+def _is_rfc3339_datetime(value):
+    if not isinstance(value, str) or RFC3339.fullmatch(value) is None:
+        return False
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed.tzinfo is not None
+
+
+VALIDATOR = Draft202012Validator(SCHEMA, format_checker=FORMAT_CHECKER)
 ACTIONS = frozenset(SCHEMA["$defs"]["action"]["enum"])
 
 

--- a/elysia_collective_seed/autopilot/contracts/checkpoint_snapshot.schema.json
+++ b/elysia_collective_seed/autopilot/contracts/checkpoint_snapshot.schema.json
@@ -1,41 +1,51 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Normative checkpoint gate snapshot, not a release credential",
+  "title": "Guardian governance snapshot v2 — normative, not production enforcement",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "revision", "source_refs", "gates", "entities"],
+  "required": ["schema_version", "snapshot_generation", "source_refs", "admission_authorities", "gates", "admissions", "migration_provenance"],
   "properties": {
-    "schema_version": {"const": 1},
-    "revision": {"type": "integer", "minimum": 1},
+    "schema_version": {"const": 2},
+    "snapshot_generation": {"type": "integer", "minimum": 1},
     "source_refs": {"$ref": "#/$defs/nonempty_refs"},
+    "admission_authorities": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/authority"}},
     "gates": {"type": "array", "items": {"$ref": "#/$defs/gate"}},
-    "entities": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/entity"}}
+    "admissions": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/admission"}},
+    "migration_provenance": {"oneOf": [{"type": "null"}, {"$ref": "#/$defs/migration_provenance"}]}
   },
   "$defs": {
     "id": {"type": "string", "minLength": 1, "pattern": "^\\S(?:.*\\S)?$"},
     "refs": {"type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/id"}},
     "nonempty_refs": {"allOf": [{"$ref": "#/$defs/refs"}], "minItems": 1},
-    "action": {"enum": ["claim", "repo_write", "semantic_write", "integration", "merge", "deploy", "external_write", "read", "static_analysis", "specification", "test_design"]},
+    "action": {"enum": ["static_read", "test_only", "docs_only", "schema_spec_write", "semantic_code_write", "repo_write", "integration", "merge", "deploy", "external_write", "permission_change", "private_data_access"]},
+    "authority": {
+      "type": "object", "additionalProperties": false,
+      "required": ["authority_id", "authority_kind", "authority_generation", "source_refs"],
+      "properties": {
+        "authority_id": {"$ref": "#/$defs/id"},
+        "authority_kind": {"enum": ["trusted_repository_control_plane", "trusted_migration_control_plane"]},
+        "authority_generation": {"type": "integer", "minimum": 1},
+        "source_refs": {"$ref": "#/$defs/nonempty_refs"}
+      }
+    },
+    "authority_ref": {
+      "type": "object", "additionalProperties": false,
+      "required": ["authority_id", "authority_generation"],
+      "properties": {"authority_id": {"$ref": "#/$defs/id"}, "authority_generation": {"type": "integer", "minimum": 1}}
+    },
     "scope": {
       "type": "object", "additionalProperties": false,
       "required": ["objective_refs", "lineage_refs"],
-      "properties": {
-        "objective_refs": {"$ref": "#/$defs/nonempty_refs"},
-        "lineage_refs": {"$ref": "#/$defs/nonempty_refs"}
-      }
+      "properties": {"objective_refs": {"$ref": "#/$defs/nonempty_refs"}, "lineage_refs": {"$ref": "#/$defs/nonempty_refs"}}
     },
     "release_claim": {
       "description": "Untrusted audit assertion. Schema validity cannot release a gate.",
       "type": "object", "additionalProperties": false,
       "required": ["gate_id", "generation", "scope", "actions", "asserted_human", "transport", "application", "evidence_refs"],
       "properties": {
-        "gate_id": {"$ref": "#/$defs/id"},
-        "generation": {"type": "integer", "minimum": 1},
-        "scope": {"$ref": "#/$defs/scope"},
+        "gate_id": {"$ref": "#/$defs/id"}, "generation": {"type": "integer", "minimum": 1}, "scope": {"$ref": "#/$defs/scope"},
         "actions": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/action"}},
-        "asserted_human": {"$ref": "#/$defs/id"},
-        "transport": {"$ref": "#/$defs/id"},
-        "application": {"$ref": "#/$defs/id"},
+        "asserted_human": {"$ref": "#/$defs/id"}, "transport": {"$ref": "#/$defs/id"}, "application": {"$ref": "#/$defs/id"},
         "evidence_refs": {"$ref": "#/$defs/nonempty_refs"}
       }
     },
@@ -43,44 +53,45 @@
       "type": "object", "additionalProperties": false,
       "required": ["gate_id", "generation", "kind", "state", "scope", "inherit_to_children", "blocked_actions", "reason", "source_refs", "release"],
       "properties": {
-        "gate_id": {"$ref": "#/$defs/id"},
-        "generation": {"type": "integer", "minimum": 1},
-        "kind": {"const": "human_governance_required"},
-        "state": {"enum": ["active", "released"]},
-        "scope": {"$ref": "#/$defs/scope"},
-        "inherit_to_children": {"const": true},
+        "gate_id": {"$ref": "#/$defs/id"}, "generation": {"type": "integer", "minimum": 1},
+        "kind": {"const": "human_governance_required"}, "state": {"enum": ["active", "released"]},
+        "scope": {"$ref": "#/$defs/scope"}, "inherit_to_children": {"const": true},
         "blocked_actions": {
-          "type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/action"},
+          "type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/action"},
           "allOf": [
-            {"contains": {"const": "claim"}}, {"contains": {"const": "repo_write"}},
-            {"contains": {"const": "semantic_write"}}, {"contains": {"const": "integration"}},
-            {"contains": {"const": "merge"}}, {"contains": {"const": "deploy"}},
-            {"contains": {"const": "external_write"}}
+            {"contains": {"const": "semantic_code_write"}}, {"contains": {"const": "repo_write"}},
+            {"contains": {"const": "integration"}}, {"contains": {"const": "merge"}},
+            {"contains": {"const": "deploy"}}, {"contains": {"const": "external_write"}},
+            {"contains": {"const": "permission_change"}}, {"contains": {"const": "private_data_access"}}
           ]
         },
-        "reason": {"$ref": "#/$defs/id"},
-        "source_refs": {"$ref": "#/$defs/nonempty_refs"},
+        "reason": {"$ref": "#/$defs/id"}, "source_refs": {"$ref": "#/$defs/nonempty_refs"},
         "release": {"oneOf": [{"type": "null"}, {"$ref": "#/$defs/release_claim"}]}
       }
     },
-    "entity": {
+    "admission": {
       "type": "object", "additionalProperties": false,
-      "required": ["entity_id", "ancestry_kind", "parent_refs", "objective_refs", "lineage_refs", "governance_gate_refs"],
+      "required": ["entity_id", "entity_kind", "ancestry_kind", "parent_refs", "repository_lineage_refs", "governance_lineage_refs", "objective_refs", "action_classes", "admission_generation", "admitted_by", "admission_source", "admission_evidence", "admitted_at", "governance_gate_refs"],
       "properties": {
-        "entity_id": {"$ref": "#/$defs/id"},
-        "ancestry_kind": {"enum": ["root", "derived"]},
-        "parent_refs": {"$ref": "#/$defs/refs"},
+        "entity_id": {"$ref": "#/$defs/id"}, "entity_kind": {"enum": ["objective", "task", "branch", "commit", "pull_request", "worktree", "artifact"]},
+        "ancestry_kind": {"enum": ["root", "derived"]}, "parent_refs": {"$ref": "#/$defs/refs"},
+        "repository_lineage_refs": {"$ref": "#/$defs/nonempty_refs"}, "governance_lineage_refs": {"$ref": "#/$defs/nonempty_refs"},
         "objective_refs": {"$ref": "#/$defs/nonempty_refs"},
-        "lineage_refs": {"$ref": "#/$defs/nonempty_refs"},
-        "governance_gate_refs": {"$ref": "#/$defs/refs"}
+        "action_classes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/action"}},
+        "admission_generation": {"type": "integer", "minimum": 1}, "admitted_by": {"$ref": "#/$defs/authority_ref"},
+        "admission_source": {"$ref": "#/$defs/nonempty_refs"}, "admission_evidence": {"$ref": "#/$defs/nonempty_refs"},
+        "admitted_at": {"type": "string", "format": "date-time"}, "governance_gate_refs": {"$ref": "#/$defs/refs"}
       },
-      "allOf": [
-        {
-          "if": {"properties": {"ancestry_kind": {"const": "root"}}},
-          "then": {"properties": {"parent_refs": {"maxItems": 0}}},
-          "else": {"properties": {"parent_refs": {"minItems": 1}}}
-        }
-      ]
+      "allOf": [{"if": {"properties": {"ancestry_kind": {"const": "root"}}}, "then": {"properties": {"parent_refs": {"maxItems": 0}}}, "else": {"properties": {"parent_refs": {"minItems": 1}}}}]
+    },
+    "migration_provenance": {
+      "type": "object", "additionalProperties": false,
+      "required": ["from_schema_version", "source_snapshot_digest", "migration_manifest_digest", "migrated_by", "migrated_at", "evidence_refs"],
+      "properties": {
+        "from_schema_version": {"const": 1}, "source_snapshot_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "migration_manifest_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}, "migrated_by": {"$ref": "#/$defs/authority_ref"},
+        "migrated_at": {"type": "string", "format": "date-time"}, "evidence_refs": {"$ref": "#/$defs/nonempty_refs"}
+      }
     }
   }
 }

--- a/elysia_collective_seed/autopilot/contracts/checkpoint_snapshot.v1.schema.json
+++ b/elysia_collective_seed/autopilot/contracts/checkpoint_snapshot.v1.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Normative checkpoint gate snapshot, not a release credential",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "revision", "source_refs", "gates", "entities"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "revision": {"type": "integer", "minimum": 1},
+    "source_refs": {"$ref": "#/$defs/nonempty_refs"},
+    "gates": {"type": "array", "items": {"$ref": "#/$defs/gate"}},
+    "entities": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/entity"}}
+  },
+  "$defs": {
+    "id": {"type": "string", "minLength": 1, "pattern": "^\\S(?:.*\\S)?$"},
+    "refs": {"type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/id"}},
+    "nonempty_refs": {"allOf": [{"$ref": "#/$defs/refs"}], "minItems": 1},
+    "action": {"enum": ["claim", "repo_write", "semantic_write", "integration", "merge", "deploy", "external_write", "read", "static_analysis", "specification", "test_design"]},
+    "scope": {
+      "type": "object", "additionalProperties": false,
+      "required": ["objective_refs", "lineage_refs"],
+      "properties": {
+        "objective_refs": {"$ref": "#/$defs/nonempty_refs"},
+        "lineage_refs": {"$ref": "#/$defs/nonempty_refs"}
+      }
+    },
+    "release_claim": {
+      "description": "Untrusted audit assertion. Schema validity cannot release a gate.",
+      "type": "object", "additionalProperties": false,
+      "required": ["gate_id", "generation", "scope", "actions", "asserted_human", "transport", "application", "evidence_refs"],
+      "properties": {
+        "gate_id": {"$ref": "#/$defs/id"},
+        "generation": {"type": "integer", "minimum": 1},
+        "scope": {"$ref": "#/$defs/scope"},
+        "actions": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/action"}},
+        "asserted_human": {"$ref": "#/$defs/id"},
+        "transport": {"$ref": "#/$defs/id"},
+        "application": {"$ref": "#/$defs/id"},
+        "evidence_refs": {"$ref": "#/$defs/nonempty_refs"}
+      }
+    },
+    "gate": {
+      "type": "object", "additionalProperties": false,
+      "required": ["gate_id", "generation", "kind", "state", "scope", "inherit_to_children", "blocked_actions", "reason", "source_refs", "release"],
+      "properties": {
+        "gate_id": {"$ref": "#/$defs/id"},
+        "generation": {"type": "integer", "minimum": 1},
+        "kind": {"const": "human_governance_required"},
+        "state": {"enum": ["active", "released"]},
+        "scope": {"$ref": "#/$defs/scope"},
+        "inherit_to_children": {"const": true},
+        "blocked_actions": {
+          "type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/action"},
+          "allOf": [
+            {"contains": {"const": "claim"}}, {"contains": {"const": "repo_write"}},
+            {"contains": {"const": "semantic_write"}}, {"contains": {"const": "integration"}},
+            {"contains": {"const": "merge"}}, {"contains": {"const": "deploy"}},
+            {"contains": {"const": "external_write"}}
+          ]
+        },
+        "reason": {"$ref": "#/$defs/id"},
+        "source_refs": {"$ref": "#/$defs/nonempty_refs"},
+        "release": {"oneOf": [{"type": "null"}, {"$ref": "#/$defs/release_claim"}]}
+      }
+    },
+    "entity": {
+      "type": "object", "additionalProperties": false,
+      "required": ["entity_id", "parent_refs", "objective_refs", "lineage_refs", "governance_gate_refs"],
+      "properties": {
+        "entity_id": {"$ref": "#/$defs/id"},
+        "parent_refs": {"$ref": "#/$defs/refs"},
+        "objective_refs": {"$ref": "#/$defs/nonempty_refs"},
+        "lineage_refs": {"$ref": "#/$defs/nonempty_refs"},
+        "governance_gate_refs": {"$ref": "#/$defs/refs"}
+      }
+    }
+  }
+}

--- a/elysia_collective_seed/autopilot/contracts/fixtures/issue_33_scope_inheritance.json
+++ b/elysia_collective_seed/autopilot/contracts/fixtures/issue_33_scope_inheritance.json
@@ -1,10 +1,16 @@
 {
-  "schema_version": 1,
-  "revision": 33,
+  "schema_version": 2,
+  "snapshot_generation": 33,
   "source_refs": [
     "https://github.com/MsElysia/Elysia/issues/33",
     "https://github.com/MsElysia/Elysia/issues/11#issuecomment-5641342345"
   ],
+  "admission_authorities": [{
+    "authority_id": "fixture:trusted-control-plane",
+    "authority_kind": "trusted_repository_control_plane",
+    "authority_generation": 1,
+    "source_refs": ["fixture:issue-33-read-only-git-evidence"]
+  }],
   "gates": [
     {
       "gate_id": "fixture:github:MsElysia/Elysia:29",
@@ -20,13 +26,14 @@
       },
       "inherit_to_children": true,
       "blocked_actions": [
-        "claim",
         "repo_write",
-        "semantic_write",
+        "semantic_code_write",
         "integration",
         "merge",
         "deploy",
-        "external_write"
+        "external_write",
+        "permission_change",
+        "private_data_access"
       ],
       "reason": "Issue #23 semantic work requires an unreleased human governance decision",
       "source_refs": [
@@ -36,70 +43,109 @@
       "release": null
     }
   ],
-  "entities": [
+  "admissions": [
     {
       "entity_id": "issue-23-objective",
+      "entity_kind": "objective",
       "ancestry_kind": "root",
       "parent_refs": [],
       "objective_refs": ["github:MsElysia/Elysia:issue:23"],
-      "lineage_refs": ["branch:autopilot-003-issue23-restack"],
+      "repository_lineage_refs": ["branch:autopilot-003-issue23-restack"],
+      "governance_lineage_refs": ["governance:issue-23"],
+      "action_classes": ["semantic_code_write", "repo_write", "integration", "merge", "external_write"],
+      "admission_generation": 1,
+      "admitted_by": {"authority_id": "fixture:trusted-control-plane", "authority_generation": 1},
+      "admission_source": ["fixture:issue-23"], "admission_evidence": ["fixture:gate-history"],
+      "admitted_at": "2026-09-11T00:00:00Z",
       "governance_gate_refs": ["fixture:github:MsElysia/Elysia:29"]
     },
     {
       "entity_id": "detached-4ff2dc92",
+      "entity_kind": "commit",
       "ancestry_kind": "derived",
       "parent_refs": ["issue-23-objective"],
       "objective_refs": ["worktree:detached-checkout"],
-      "lineage_refs": ["commit:4ff2dc92dd7d9bc393225bce35de9239a9cad6a5"],
+      "repository_lineage_refs": ["commit:4ff2dc92dd7d9bc393225bce35de9239a9cad6a5"],
+      "governance_lineage_refs": ["governance:issue-23"],
+      "action_classes": ["semantic_code_write", "repo_write"], "admission_generation": 2,
+      "admitted_by": {"authority_id": "fixture:trusted-control-plane", "authority_generation": 1},
+      "admission_source": ["fixture:git"], "admission_evidence": ["fixture:commit-parent"], "admitted_at": "2026-09-11T00:01:00Z",
       "governance_gate_refs": []
     },
     {
       "entity_id": "cursor-side-branch",
+      "entity_kind": "branch",
       "ancestry_kind": "derived",
       "parent_refs": ["detached-4ff2dc92"],
       "objective_refs": ["task:construct-without-activate-port"],
-      "lineage_refs": ["branch:cursor/autopilot-003-issue23-restack-cwa"],
+      "repository_lineage_refs": ["branch:cursor/autopilot-003-issue23-restack-cwa"],
+      "governance_lineage_refs": ["governance:issue-23"],
+      "action_classes": ["semantic_code_write", "repo_write", "external_write"], "admission_generation": 3,
+      "admitted_by": {"authority_id": "fixture:trusted-control-plane", "authority_generation": 1},
+      "admission_source": ["fixture:git"], "admission_evidence": ["fixture:branch-base"], "admitted_at": "2026-09-11T00:02:00Z",
       "governance_gate_refs": []
     },
     {
       "entity_id": "product-7374820",
+      "entity_kind": "commit",
       "ancestry_kind": "derived",
       "parent_refs": ["cursor-side-branch"],
       "objective_refs": ["product:cwa-restack"],
-      "lineage_refs": ["commit:7374820642fad52a6264c86df8632c3a630df592"],
+      "repository_lineage_refs": ["commit:7374820642fad52a6264c86df8632c3a630df592"],
+      "governance_lineage_refs": ["governance:issue-23"],
+      "action_classes": ["semantic_code_write", "repo_write", "external_write", "integration"], "admission_generation": 4,
+      "admitted_by": {"authority_id": "fixture:trusted-control-plane", "authority_generation": 1},
+      "admission_source": ["fixture:git"], "admission_evidence": ["fixture:diff-classification"], "admitted_at": "2026-09-11T00:03:00Z",
       "governance_gate_refs": []
     },
     {
       "entity_id": "restack-v2-sibling",
+      "entity_kind": "branch",
       "ancestry_kind": "derived",
       "parent_refs": ["detached-4ff2dc92"],
       "objective_refs": ["task:restack-v2"],
-      "lineage_refs": ["branch:restack-v2"],
+      "repository_lineage_refs": ["branch:restack-v2"], "governance_lineage_refs": ["governance:issue-23"],
+      "action_classes": ["semantic_code_write", "repo_write"], "admission_generation": 4,
+      "admitted_by": {"authority_id": "fixture:trusted-control-plane", "authority_generation": 1},
+      "admission_source": ["fixture:git"], "admission_evidence": ["fixture:sibling-base"], "admitted_at": "2026-09-11T00:03:00Z",
       "governance_gate_refs": []
     },
     {
       "entity_id": "renamed-worker-task",
+      "entity_kind": "task",
       "ancestry_kind": "derived",
       "parent_refs": ["product-7374820"],
       "objective_refs": ["task:apparently-unrelated-name"],
-      "lineage_refs": ["worker:substitute"],
+      "repository_lineage_refs": ["worker:substitute"], "governance_lineage_refs": ["governance:issue-23"],
+      "action_classes": ["semantic_code_write"], "admission_generation": 5,
+      "admitted_by": {"authority_id": "fixture:trusted-control-plane", "authority_generation": 1},
+      "admission_source": ["fixture:control-plane"], "admission_evidence": ["fixture:task-link"], "admitted_at": "2026-09-11T00:04:00Z",
       "governance_gate_refs": []
     },
     {
       "entity_id": "salami-slice-a",
+      "entity_kind": "commit",
       "ancestry_kind": "derived",
       "parent_refs": ["cursor-side-branch"],
       "objective_refs": ["slice:singleton"],
-      "lineage_refs": ["commit:candidate-a"],
+      "repository_lineage_refs": ["commit:candidate-a"], "governance_lineage_refs": ["governance:issue-23"],
+      "action_classes": ["semantic_code_write"], "admission_generation": 5,
+      "admitted_by": {"authority_id": "fixture:trusted-control-plane", "authority_generation": 1},
+      "admission_source": ["fixture:git"], "admission_evidence": ["fixture:diff-a"], "admitted_at": "2026-09-11T00:04:00Z",
       "governance_gate_refs": []
     },
     {
       "entity_id": "salami-slice-b",
+      "entity_kind": "commit",
       "ancestry_kind": "derived",
       "parent_refs": ["salami-slice-a"],
       "objective_refs": ["slice:activation"],
-      "lineage_refs": ["commit:candidate-b"],
+      "repository_lineage_refs": ["commit:candidate-b"], "governance_lineage_refs": ["governance:issue-23"],
+      "action_classes": ["semantic_code_write"], "admission_generation": 6,
+      "admitted_by": {"authority_id": "fixture:trusted-control-plane", "authority_generation": 1},
+      "admission_source": ["fixture:git"], "admission_evidence": ["fixture:diff-b"], "admitted_at": "2026-09-11T00:05:00Z",
       "governance_gate_refs": []
     }
-  ]
+  ],
+  "migration_provenance": null
 }

--- a/elysia_collective_seed/autopilot/contracts/test_admission_v2.py
+++ b/elysia_collective_seed/autopilot/contracts/test_admission_v2.py
@@ -1,0 +1,243 @@
+"""V2 admission/migration falsification; no production service or trust anchor."""
+from copy import deepcopy
+
+import pytest
+
+from .admission import AdmissionError, evaluate_admitted, migrate_v1_to_v2, validate_snapshot_version
+from .checkpoint_reference import VALIDATOR, snapshot_digest
+
+
+AUTHORITY = {
+    "authority_id": "migration-control-plane",
+    "authority_kind": "trusted_migration_control_plane",
+    "authority_generation": 4,
+    "source_refs": ["fixture:authority-registry"],
+}
+AUTHORITY_REF = {"authority_id": "migration-control-plane", "authority_generation": 4}
+OLD_BLOCKS = ["claim", "repo_write", "semantic_write", "integration", "merge", "deploy", "external_write"]
+
+
+def legacy_v1():
+    return {
+        "schema_version": 1, "revision": 7, "source_refs": ["fixture:v1"],
+        "gates": [{
+            "gate_id": "gate:23", "generation": 3,
+            "kind": "human_governance_required", "state": "active",
+            "scope": {"objective_refs": ["issue:23"], "lineage_refs": ["governance:23"]},
+            "inherit_to_children": True, "blocked_actions": OLD_BLOCKS[:],
+            "reason": "human decision required", "source_refs": ["issue:29"], "release": None,
+        }],
+        "entities": [
+            {"entity_id": "root", "parent_refs": [], "objective_refs": ["issue:23"],
+             "lineage_refs": ["branch:restack"], "governance_gate_refs": ["gate:23"]},
+            {"entity_id": "child", "parent_refs": ["root"], "objective_refs": ["task:renamed"],
+             "lineage_refs": ["commit:child"], "governance_gate_refs": []},
+        ],
+    }
+
+
+def decision(source, *, kind, entity_kind, action="semantic_code_write", root_evidence=None):
+    result = {
+        "entity_id": source["entity_id"], "entity_kind": entity_kind,
+        "ancestry_kind": kind, "parent_refs": deepcopy(source["parent_refs"]),
+        "repository_lineage_refs": deepcopy(source["lineage_refs"]),
+        "governance_lineage_refs": ["governance:23"],
+        "objective_refs": deepcopy(source["objective_refs"]), "action_classes": [action],
+        "admission_generation": 8, "admitted_by": deepcopy(AUTHORITY_REF),
+        "admission_source": ["fixture:migration-manifest"],
+        "admission_evidence": ["fixture:repository-proof"],
+        "admitted_at": "2026-09-12T00:00:00Z",
+        "governance_gate_refs": deepcopy(source["governance_gate_refs"]),
+    }
+    if root_evidence is not None:
+        result["root_admission_evidence"] = root_evidence
+    return result
+
+
+def manifest(source=None):
+    source = source or legacy_v1()
+    return {
+        "from_schema_version": 1, "to_schema_version": 2,
+        "target_snapshot_generation": 8,
+        "migration_authority": deepcopy(AUTHORITY_REF),
+        "migrated_at": "2026-09-12T00:00:00Z", "evidence_refs": ["fixture:migration-review"],
+        "admissions": [
+            decision(source["entities"][0], kind="root", entity_kind="objective",
+                     root_evidence=["fixture:explicit-root-admission"]),
+            decision(source["entities"][1], kind="derived", entity_kind="commit"),
+        ],
+    }
+
+
+def migrate(source=None, plan=None, **kwargs):
+    source = source or legacy_v1()
+    return migrate_v1_to_v2(
+        source, plan or manifest(source), trusted_source_digest=snapshot_digest(source),
+        trusted_authorities=[AUTHORITY], **kwargs,
+    )
+
+
+def test_v1_is_rejected_by_v2_and_requires_explicit_migration():
+    source = legacy_v1()
+    assert not VALIDATOR.is_valid(source)
+    with pytest.raises(AdmissionError, match="unsupported_schema_version"):
+        validate_snapshot_version(source)
+    target = migrate(source)
+    assert target["schema_version"] == 2
+    assert target["migration_provenance"]["source_snapshot_digest"] == snapshot_digest(source)
+
+
+def test_migration_is_deterministic_and_preserves_gate_scope_and_release_denial():
+    source = legacy_v1()
+    first = migrate(source)
+    second = migrate(deepcopy(source), deepcopy(manifest(source)))
+    assert first == second
+    assert first["gates"][0]["gate_id"] == "gate:23"
+    assert first["gates"][0]["generation"] == 3
+    assert first["gates"][0]["scope"] == source["gates"][0]["scope"]
+    result = evaluate_admitted(first, "child", "semantic_code_write",
+        trusted_current_digest=snapshot_digest(first))
+    assert result.disposition == "BLOCKED_PENDING_HUMAN_RELEASE"
+    assert result.release_validation == "UNAVAILABLE"
+
+
+@pytest.mark.parametrize("version", [0, 1, 3, 999, "2", None])
+def test_unknown_downgrade_and_forward_versions_fail_closed(version):
+    target = migrate()
+    target["schema_version"] = version
+    with pytest.raises(AdmissionError, match="unsupported_schema_version"):
+        validate_snapshot_version(target)
+
+
+def test_generation_rollback_and_stale_digest_fail():
+    source = legacy_v1()
+    plan = manifest(source)
+    plan["target_snapshot_generation"] = source["revision"]
+    with pytest.raises(AdmissionError, match="target_generation_not_monotonic"):
+        migrate(source, plan)
+    target = migrate(source)
+    with pytest.raises(AdmissionError, match="snapshot_generation_rollback"):
+        validate_snapshot_version(target, minimum_generation=9)
+    with pytest.raises(AdmissionError, match="stale_or_untrusted_source_digest"):
+        migrate_v1_to_v2(source, manifest(source), trusted_source_digest="0" * 64,
+                         trusted_authorities=[AUTHORITY])
+
+
+def test_empty_parents_do_not_automatically_mean_root():
+    source = legacy_v1()
+    plan = manifest(source)
+    plan["admissions"][0].pop("root_admission_evidence")
+    with pytest.raises(AdmissionError, match="root_requires_explicit_migration_evidence"):
+        migrate(source, plan)
+    plan = manifest(source)
+    plan["admissions"][0]["ancestry_kind"] = "derived"
+    with pytest.raises(AdmissionError, match="empty_parents_are_ambiguous"):
+        migrate(source, plan)
+
+
+def test_worker_authority_and_unknown_authority_fail():
+    source = legacy_v1()
+    plan = manifest(source)
+    plan["migration_authority"] = {"authority_id": "worker", "authority_generation": 1}
+    with pytest.raises(AdmissionError, match="unknown_migration_authority"):
+        migrate(source, plan)
+    target = migrate(source)
+    target["admissions"][0]["admitted_by"] = {"authority_id": "worker", "authority_generation": 1}
+    result = evaluate_admitted(target, "root", "semantic_code_write",
+        trusted_current_digest=snapshot_digest(target))
+    assert result.disposition == "BLOCKED_INVALID_STATE"
+
+
+@pytest.mark.parametrize("field", ["objective_refs", "parent_refs"])
+def test_migration_cannot_rewrite_objective_ancestry_or_gate_refs(field):
+    source = legacy_v1()
+    plan = manifest(source)
+    plan["admissions"][1][field] = []
+    with pytest.raises(AdmissionError):
+        migrate(source, plan)
+
+
+def test_migration_cannot_drop_gate_refs():
+    source = legacy_v1()
+    plan = manifest(source)
+    plan["admissions"][0]["governance_gate_refs"] = []
+    with pytest.raises(AdmissionError, match="cannot_drop_gate_refs"):
+        migrate(source, plan)
+
+
+def test_migration_cannot_drop_repository_or_governance_lineage():
+    source = legacy_v1()
+    plan = manifest(source)
+    plan["admissions"][1]["repository_lineage_refs"] = ["branch:friendly"]
+    with pytest.raises(AdmissionError, match="cannot_drop_repository_lineage"):
+        migrate(source, plan)
+    plan = manifest(source)
+    plan["admissions"][1]["governance_lineage_refs"] = []
+    with pytest.raises(AdmissionError, match="invalid_v2_snapshot"):
+        migrate(source, plan)
+
+
+def test_conflicting_or_incomplete_admission_records_fail():
+    source = legacy_v1()
+    plan = manifest(source)
+    plan["admissions"].append(deepcopy(plan["admissions"][0]))
+    with pytest.raises(AdmissionError, match="exactly_once"):
+        migrate(source, plan)
+    plan = manifest(source)
+    plan["admissions"].pop()
+    with pytest.raises(AdmissionError, match="exactly_once"):
+        migrate(source, plan)
+
+
+def test_worker_proposal_cannot_downgrade_objective_or_action():
+    target = migrate()
+    result = evaluate_admitted(
+        target, "child", "semantic_code_write",
+        trusted_current_digest=snapshot_digest(target),
+        worker_proposal={"objective_refs": ["unrelated"], "action": "docs_only", "ancestry_kind": "root"},
+    )
+    assert result.disposition == "BLOCKED_PENDING_HUMAN_RELEASE"
+    downgraded = evaluate_admitted(target, "child", "docs_only",
+        trusted_current_digest=snapshot_digest(target), worker_proposal={"action": "docs_only"})
+    assert downgraded.disposition == "BLOCKED_INVALID_STATE"
+    assert downgraded.reason == "action_not_admitted"
+
+
+def test_ambiguous_action_and_unknown_entity_fail_closed():
+    target = migrate()
+    for entity, action in (("child", "unknown"), ("missing", "semantic_code_write")):
+        result = evaluate_admitted(target, entity, action,
+            trusted_current_digest=snapshot_digest(target))
+        assert result.disposition == "BLOCKED_INVALID_STATE"
+
+
+def test_released_v1_gate_stays_effective_after_migration():
+    source = legacy_v1()
+    gate = source["gates"][0]
+    gate["state"] = "released"
+    gate["release"] = {
+        "gate_id": "gate:23", "generation": 3, "scope": deepcopy(gate["scope"]),
+        "actions": OLD_BLOCKS[:], "asserted_human": "owner", "transport": "app",
+        "application": "connector", "evidence_refs": ["fixture:unverified"],
+    }
+    target = migrate(source)
+    result = evaluate_admitted(target, "child", "semantic_code_write",
+        trusted_current_digest=snapshot_digest(target))
+    assert result.disposition == "BLOCKED_PENDING_HUMAN_RELEASE"
+    assert result.release_validation == "UNAVAILABLE"
+
+
+def test_unrelated_admitted_root_is_no_match_not_authorization():
+    source = legacy_v1()
+    source["entities"] = [source["entities"][0]]
+    source["entities"][0]["objective_refs"] = ["issue:999"]
+    source["entities"][0]["lineage_refs"] = ["branch:unrelated"]
+    source["entities"][0]["governance_gate_refs"] = []
+    plan = manifest(legacy_v1())
+    plan["admissions"] = [decision(source["entities"][0], kind="root", entity_kind="task",
+        action="static_read", root_evidence=["fixture:trusted-new-root"])]
+    target = migrate(source, plan)
+    result = evaluate_admitted(target, "root", "static_read",
+        trusted_current_digest=snapshot_digest(target))
+    assert result.disposition == "NO_MATCHING_BLOCK_NOT_AUTHORIZATION"
+    assert result.external_write_enforcement == "NOT_ENFORCED"

--- a/elysia_collective_seed/autopilot/contracts/test_admission_v2_adversarial.py
+++ b/elysia_collective_seed/autopilot/contracts/test_admission_v2_adversarial.py
@@ -1,0 +1,328 @@
+"""Regression coverage for trusted-admission fail-closed boundaries.
+
+These assertions state the fail-closed behavior promised by
+GOVERNANCE_V2_ADMISSION.md. They live outside the candidate worktree.
+"""
+from copy import deepcopy
+
+import pytest
+
+from elysia_collective_seed.autopilot.contracts.admission import (
+    AdmissionError,
+    evaluate_admitted,
+    migrate_v1_to_v2,
+    validate_snapshot_version,
+)
+from elysia_collective_seed.autopilot.contracts.checkpoint_reference import snapshot_digest
+
+AUTHORITY = {
+    "authority_id": "migration-control-plane",
+    "authority_kind": "trusted_migration_control_plane",
+    "authority_generation": 4,
+    "source_refs": ["vega:independent-registry"],
+}
+AUTHORITY_REF = {"authority_id": "migration-control-plane", "authority_generation": 4}
+OLD_BLOCKS = ["claim", "repo_write", "semantic_write", "integration", "merge", "deploy", "external_write"]
+
+
+def legacy_v1():
+    return {
+        "schema_version": 1,
+        "revision": 7,
+        "source_refs": ["vega:v1"],
+        "gates": [{
+            "gate_id": "gate:23",
+            "generation": 3,
+            "kind": "human_governance_required",
+            "state": "active",
+            "scope": {"objective_refs": ["issue:23"], "lineage_refs": ["governance:23"]},
+            "inherit_to_children": True,
+            "blocked_actions": OLD_BLOCKS[:],
+            "reason": "human decision required",
+            "source_refs": ["issue:29"],
+            "release": None,
+        }],
+        "entities": [
+            {
+                "entity_id": "root",
+                "parent_refs": [],
+                "objective_refs": ["issue:23"],
+                "lineage_refs": ["branch:restack"],
+                "governance_gate_refs": ["gate:23"],
+            },
+            {
+                "entity_id": "child",
+                "parent_refs": ["root"],
+                "objective_refs": ["task:renamed"],
+                "lineage_refs": ["commit:child"],
+                "governance_gate_refs": [],
+            },
+        ],
+    }
+
+
+def admission(entity, ancestry_kind, entity_kind):
+    result = {
+        "entity_id": entity["entity_id"],
+        "entity_kind": entity_kind,
+        "ancestry_kind": ancestry_kind,
+        "parent_refs": deepcopy(entity["parent_refs"]),
+        "repository_lineage_refs": deepcopy(entity["lineage_refs"]),
+        "governance_lineage_refs": ["governance:23"],
+        "objective_refs": deepcopy(entity["objective_refs"]),
+        "action_classes": ["semantic_code_write"],
+        "admission_generation": 8,
+        "admitted_by": deepcopy(AUTHORITY_REF),
+        "admission_source": ["vega:manifest"],
+        "admission_evidence": ["vega:repository-proof"],
+        "admitted_at": "2026-09-12T00:00:00Z",
+        "governance_gate_refs": deepcopy(entity["governance_gate_refs"]),
+    }
+    if ancestry_kind == "root":
+        result["root_admission_evidence"] = ["vega:explicit-root-proof"]
+    return result
+
+
+def manifest(source):
+    return {
+        "from_schema_version": 1,
+        "to_schema_version": 2,
+        "target_snapshot_generation": 8,
+        "migration_authority": deepcopy(AUTHORITY_REF),
+        "migrated_at": "2026-09-12T00:00:00Z",
+        "evidence_refs": ["vega:migration-review"],
+        "admissions": [
+            admission(source["entities"][0], "root", "objective"),
+            admission(source["entities"][1], "derived", "commit"),
+        ],
+    }
+
+
+def migrate(source, plan=None, authorities=None):
+    return migrate_v1_to_v2(
+        source,
+        plan if plan is not None else manifest(source),
+        trusted_source_digest=snapshot_digest(source),
+        trusted_authorities=authorities if authorities is not None else [AUTHORITY],
+    )
+
+
+def test_control_semantic_restack_remains_blocked_and_worker_labels_are_ignored():
+    source = legacy_v1()
+    target = migrate(source)
+    result = evaluate_admitted(
+        target,
+        "child",
+        "semantic_code_write",
+        trusted_current_digest=snapshot_digest(target),
+        worker_proposal={
+            "ancestry_kind": "root",
+            "objective_refs": ["friendly:unrelated"],
+            "action": "docs_only",
+        },
+    )
+    assert result.disposition == "BLOCKED_PENDING_HUMAN_RELEASE"
+    assert result.effective_active_gates == (("gate:23", 3),)
+    assert result.release_validation == "UNAVAILABLE"
+    assert result.external_write_enforcement == "NOT_ENFORCED"
+
+
+def test_control_wrong_digest_and_unknown_authority_block():
+    source = legacy_v1()
+    target = migrate(source)
+    assert evaluate_admitted(
+        target, "root", "semantic_code_write", trusted_current_digest="0" * 64
+    ).disposition == "BLOCKED_INVALID_STATE"
+    target["admissions"][0]["admitted_by"] = {
+        "authority_id": "worker", "authority_generation": 1
+    }
+    assert evaluate_admitted(
+        target, "root", "semantic_code_write", trusted_current_digest=snapshot_digest(target)
+    ).disposition == "BLOCKED_INVALID_STATE"
+
+
+@pytest.mark.parametrize("version", [True, 1.0])
+def test_migration_rejects_non_integer_exact_v1_version(version):
+    source = legacy_v1()
+    source["schema_version"] = version
+    with pytest.raises(AdmissionError, match="source_must_be_v1"):
+        migrate(source)
+
+
+@pytest.mark.parametrize("version", [2.0])
+def test_v2_validator_rejects_non_integer_runtime_version(version):
+    source = legacy_v1()
+    target = migrate(source)
+    target["schema_version"] = version
+    with pytest.raises(AdmissionError, match="unsupported_schema_version"):
+        validate_snapshot_version(target)
+
+
+def test_migration_wraps_malformed_legacy_gate_as_admission_error():
+    source = legacy_v1()
+    del source["gates"][0]["blocked_actions"]
+    with pytest.raises(AdmissionError):
+        migrate(source)
+
+
+def test_migration_rejects_missing_parent_before_returning_snapshot():
+    source = legacy_v1()
+    source["entities"][1]["parent_refs"] = ["absent-parent"]
+    target_manifest = manifest(source)
+    with pytest.raises(AdmissionError, match="parent|ancestry|invalid",):
+        migrate(source, target_manifest)
+
+
+def test_migration_rejects_duplicate_gate_identity_before_returning_snapshot():
+    source = legacy_v1()
+    source["gates"].append(deepcopy(source["gates"][0]))
+    with pytest.raises(AdmissionError, match="duplicate|invalid"):
+        migrate(source)
+
+
+def test_migration_rejects_duplicate_trusted_authority_identity():
+    source = legacy_v1()
+    duplicate = deepcopy(AUTHORITY)
+    duplicate["source_refs"] = ["vega:conflicting-registry-entry"]
+    with pytest.raises(AdmissionError, match="duplicate|authority"):
+        migrate(source, authorities=[AUTHORITY, duplicate])
+
+
+def test_migration_rejects_admission_bound_to_unregistered_authority():
+    source = legacy_v1()
+    target_manifest = manifest(source)
+    target_manifest["admissions"][1]["admitted_by"] = {
+        "authority_id": "worker", "authority_generation": 1
+    }
+    with pytest.raises(AdmissionError, match="authority|invalid"):
+        migrate(source, target_manifest)
+
+
+def test_declared_datetime_format_is_enforced_by_reference_validator():
+    source = legacy_v1()
+    target = migrate(source)
+    target["admissions"][0]["admitted_at"] = "not-a-date-time"
+    with pytest.raises(AdmissionError, match="invalid_v2_snapshot"):
+        validate_snapshot_version(target)
+
+@pytest.mark.parametrize("version", [None, False, 0, 1, 3, 999, "2"])
+def test_control_unknown_downgrade_forward_v2_versions_block(version):
+    source = legacy_v1()
+    target = migrate(source)
+    target["schema_version"] = version
+    with pytest.raises(AdmissionError):
+        validate_snapshot_version(target)
+
+
+def test_control_generation_rollback_and_stale_source_digest_block():
+    source = legacy_v1()
+    target = migrate(source)
+    with pytest.raises(AdmissionError, match="snapshot_generation_rollback"):
+        validate_snapshot_version(target, minimum_generation=9)
+    with pytest.raises(AdmissionError, match="stale_or_untrusted_source_digest"):
+        migrate_v1_to_v2(
+            source,
+            manifest(source),
+            trusted_source_digest="0" * 64,
+            trusted_authorities=[AUTHORITY],
+        )
+
+
+def test_control_missing_root_evidence_blocks():
+    source = legacy_v1()
+    target_manifest = manifest(source)
+    target_manifest["admissions"][0].pop("root_admission_evidence")
+    with pytest.raises(AdmissionError, match="root_requires_explicit_migration_evidence"):
+        migrate(source, target_manifest)
+
+
+@pytest.mark.parametrize(
+    ("entity_index", "field", "replacement"),
+    [
+        (0, "objective_refs", ["friendly:replacement"]),
+        (1, "parent_refs", ["friendly:replacement"]),
+        (0, "governance_gate_refs", []),
+        (1, "repository_lineage_refs", ["branch:friendly"]),
+        (1, "governance_lineage_refs", []),
+    ],
+)
+def test_control_migration_cannot_drop_or_rewrite_scope(entity_index, field, replacement):
+    source = legacy_v1()
+    target_manifest = manifest(source)
+    target_manifest["admissions"][entity_index][field] = replacement
+    with pytest.raises(AdmissionError):
+        migrate(source, target_manifest)
+
+
+def test_control_released_assertion_remains_blocked_and_unvalidated():
+    source = legacy_v1()
+    gate = source["gates"][0]
+    gate["state"] = "released"
+    gate["release"] = {
+        "gate_id": gate["gate_id"],
+        "generation": gate["generation"],
+        "scope": deepcopy(gate["scope"]),
+        "actions": OLD_BLOCKS[:],
+        "asserted_human": "owner",
+        "transport": "app",
+        "application": "connector",
+        "evidence_refs": ["vega:unverified-release"],
+    }
+    target = migrate(source)
+    result = evaluate_admitted(
+        target, "child", "semantic_code_write", trusted_current_digest=snapshot_digest(target)
+    )
+    assert result.disposition == "BLOCKED_PENDING_HUMAN_RELEASE"
+    assert result.release_validation == "UNAVAILABLE"
+    assert result.external_write_enforcement == "NOT_ENFORCED"
+
+
+def test_control_unrelated_no_match_never_reports_authorization():
+    source = legacy_v1()
+    source["entities"] = [source["entities"][0]]
+    source["entities"][0]["objective_refs"] = ["issue:999"]
+    source["entities"][0]["lineage_refs"] = ["branch:unrelated"]
+    source["entities"][0]["governance_gate_refs"] = []
+    target_manifest = manifest(legacy_v1())
+    root_decision = admission(source["entities"][0], "root", "task")
+    root_decision["action_classes"] = ["static_read"]
+    target_manifest["admissions"] = [root_decision]
+    target = migrate(source, target_manifest)
+    result = evaluate_admitted(
+        target, "root", "static_read", trusted_current_digest=snapshot_digest(target)
+    )
+    assert result.disposition == "NO_MATCHING_BLOCK_NOT_AUTHORIZATION"
+    assert result.external_write_enforcement == "NOT_ENFORCED"
+
+
+def test_control_repository_and_governance_lineage_each_preserve_gate_match():
+    source = legacy_v1()
+    for matching_ref, repository_refs, governance_ref in [
+        ("commit:child", ["commit:child"], "governance:unrelated"),
+        ("governance:semantic-restack", ["commit:child", "commit:unrelated"], "governance:semantic-restack"),
+    ]:
+        case = deepcopy(source)
+        case["gates"][0]["scope"]["objective_refs"] = ["issue:unrelated"]
+        case["gates"][0]["scope"]["lineage_refs"] = [matching_ref]
+        target_manifest = manifest(case)
+        target_manifest["admissions"][1]["repository_lineage_refs"] = repository_refs
+        target_manifest["admissions"][1]["governance_lineage_refs"] = [governance_ref]
+        target = migrate(case, target_manifest)
+        result = evaluate_admitted(
+            target, "child", "semantic_code_write", trusted_current_digest=snapshot_digest(target)
+        )
+        assert result.disposition == "BLOCKED_PENDING_HUMAN_RELEASE"
+
+
+def test_migration_wraps_noniterable_authority_config_as_admission_error():
+    source = legacy_v1()
+    with pytest.raises(AdmissionError):
+        migrate_v1_to_v2(
+            source,
+            manifest(source),
+            trusted_source_digest=snapshot_digest(source),
+            trusted_authorities=None,
+        )
+
+
+

--- a/elysia_collective_seed/autopilot/contracts/test_admission_v2_adversarial.py
+++ b/elysia_collective_seed/autopilot/contracts/test_admission_v2_adversarial.py
@@ -326,3 +326,28 @@ def test_migration_wraps_noniterable_authority_config_as_admission_error():
 
 
 
+
+@pytest.mark.parametrize("timestamp", ["2026-09-12T00:00:00+01:60", "2026-02-30T00:00:00Z"])
+def test_invalid_rfc3339_timestamp_is_rejected(timestamp):
+    source = legacy_v1()
+    target = migrate(source)
+    target["admissions"][0]["admitted_at"] = timestamp
+    with pytest.raises(AdmissionError, match="invalid_v2_snapshot"):
+        validate_snapshot_version(target)
+
+
+def test_rfc3339_leap_second_is_accepted():
+    source = legacy_v1()
+    target = migrate(source)
+    target["admissions"][0]["admitted_at"] = "2026-12-31T23:59:60Z"
+    validate_snapshot_version(target)
+
+
+@pytest.mark.parametrize("bad", [None, "one", 1.5, True, [], {}])
+def test_malformed_minimum_generation_fails_closed(bad):
+    source = legacy_v1()
+    with pytest.raises(AdmissionError):
+        migrate_v1_to_v2(
+            source, manifest(source), trusted_source_digest=snapshot_digest(source),
+            trusted_authorities=[AUTHORITY], minimum_target_generation=bad,
+        )

--- a/elysia_collective_seed/autopilot/contracts/test_checkpoint_contract.py
+++ b/elysia_collective_seed/autopilot/contracts/test_checkpoint_contract.py
@@ -8,44 +8,54 @@ from jsonschema import Draft202012Validator
 from .checkpoint_reference import SCHEMA, VALIDATOR, evaluate, snapshot_digest
 
 
-BLOCKED = ["claim", "repo_write", "semantic_write", "integration", "merge", "deploy", "external_write"]
+BLOCKED = ["semantic_code_write", "repo_write", "integration", "merge", "deploy", "external_write", "permission_change", "private_data_access"]
+AUTHORITY = {"authority_id": "control-plane", "authority_generation": 1}
 
 
 def machine_state():
     # Synthetic reconstruction of #28/#29 at 9b21e002; generation 1 is a fixture,
     # not an assertion that GitHub already contains a durable numbered gate.
     return {
-        "schema_version": 1, "revision": 1,
+        "schema_version": 2, "snapshot_generation": 1,
         "source_refs": ["https://github.com/MsElysia/Elysia/issues/11#issuecomment-5636666687"],
+        "admission_authorities": [{"authority_id": "control-plane", "authority_kind": "trusted_repository_control_plane", "authority_generation": 1, "source_refs": ["fixture:authority"]}],
         "gates": [{
             "gate_id": "fixture:github:MsElysia/Elysia:29", "generation": 1,
             "kind": "human_governance_required", "state": "active",
             "scope": {"objective_refs": ["github:MsElysia/Elysia:issue:23"],
-                      "lineage_refs": ["autopilot-003-issue23-restack"]},
+                      "lineage_refs": ["branch:autopilot-003-issue23-restack"]},
             "inherit_to_children": True, "blocked_actions": BLOCKED[:],
             "reason": "Unreleased lineage decision",
             "source_refs": ["https://github.com/MsElysia/Elysia/issues/29",
                             "commit:9b21e002a8d65735469e7038a22853a444ee7e1c"],
             "release": None,
         }],
-        "entities": [{
-            "entity_id": "root", "ancestry_kind": "root", "parent_refs": [],
+        "admissions": [{
+            "entity_id": "root", "entity_kind": "objective", "ancestry_kind": "root", "parent_refs": [],
             "objective_refs": ["github:MsElysia/Elysia:issue:23"],
-            "lineage_refs": ["autopilot-003-issue23-restack"],
+            "repository_lineage_refs": ["branch:autopilot-003-issue23-restack"],
+            "governance_lineage_refs": ["governance:issue-23"],
+            "action_classes": BLOCKED + ["static_read", "test_only", "docs_only", "schema_spec_write"],
+            "admission_generation": 1, "admitted_by": AUTHORITY,
+            "admission_source": ["fixture:source"], "admission_evidence": ["fixture:evidence"],
+            "admitted_at": "2026-09-11T00:00:00Z",
             "governance_gate_refs": [],
         }],
+        "migration_provenance": None,
     }
 
 
-def inspect(state, entity="root", action="semantic_write", checkpoint=None, pin=None):
+def inspect(state, entity="root", action="semantic_code_write", checkpoint=None, pin=None):
     return evaluate(state, {"entity_id": entity, "action": action},
                     trusted_current_digest=pin or snapshot_digest(state), checkpoint=checkpoint)
 
 
 def child(name, parents):
-    return {"entity_id": name, "ancestry_kind": "derived" if parents else "root", "parent_refs": parents,
-            "objective_refs": [f"objective:{name}"], "lineage_refs": [f"branch:{name}"],
-            "governance_gate_refs": []}
+    return {"entity_id": name, "entity_kind": "task", "ancestry_kind": "derived" if parents else "root", "parent_refs": parents,
+            "objective_refs": [f"objective:{name}"], "repository_lineage_refs": [f"branch:{name}"],
+            "governance_lineage_refs": [f"governance:{name}"], "action_classes": BLOCKED + ["static_read", "test_only", "docs_only", "schema_spec_write"],
+            "admission_generation": 1, "admitted_by": AUTHORITY, "admission_source": ["fixture:source"],
+            "admission_evidence": ["fixture:evidence"], "admitted_at": "2026-09-11T00:00:00Z", "governance_gate_refs": []}
 
 
 def release_claim(gate):
@@ -76,9 +86,9 @@ def test_checkpoint_omission_conflict_or_owner_claim_cannot_clear_gate(action, c
 def test_child_restack_and_salami_slices_inherit_all_ancestors():
     state = machine_state()
     for i in range(30):
-        state["entities"].append(child(f"slice-{i}", [f"slice-{i-1}" if i else "root"]))
+        state["admissions"].append(child(f"slice-{i}", [f"slice-{i-1}" if i else "root"]))
     # Unsorted storage and renamed child metadata cannot sever graph ancestry.
-    state["entities"].reverse()
+    state["admissions"].reverse()
     for i in range(30):
         assert inspect(state, f"slice-{i}").disposition == "BLOCKED_PENDING_HUMAN_RELEASE"
 
@@ -91,18 +101,18 @@ def test_multiple_parents_and_multiple_gates_union_without_newest_wins():
     state["gates"].append(extra)
     other = child("other-root", [])
     other["governance_gate_refs"] = ["second"]
-    state["entities"] += [other, child("combined", ["root", "other-root"])]
+    state["admissions"] += [other, child("combined", ["root", "other-root"])]
     result = inspect(state, "combined")
     assert result.effective_active_gates == (("fixture:github:MsElysia/Elysia:29", 1), ("second", 7))
 
 
-@pytest.mark.parametrize("preserved", ["objective_refs", "lineage_refs", "governance_gate_refs"])
+@pytest.mark.parametrize("preserved", ["objective_refs", "repository_lineage_refs", "governance_gate_refs"])
 def test_each_independent_scope_match_is_sufficient(preserved):
     state = machine_state()
     node = child("renamed", [])
-    node[preserved] = (state["entities"][0][preserved] if preserved != "governance_gate_refs"
+    node[preserved] = (state["admissions"][0][preserved] if preserved != "governance_gate_refs"
                        else [state["gates"][0]["gate_id"]])
-    state["entities"] = [node]
+    state["admissions"] = [node]
     assert inspect(state, "renamed").disposition == "BLOCKED_PENDING_HUMAN_RELEASE"
 
 
@@ -139,18 +149,18 @@ def test_new_generation_cannot_use_prior_release():
 @pytest.mark.parametrize("mutation", ["remove_gate", "replace_gate", "rename_objective", "erase_ancestry", "old_revision"])
 def test_snapshot_tampering_or_rollback_cannot_match_independent_current_pin(mutation):
     state = machine_state()
-    state["entities"].append(child("descendant", ["root"]))
+    state["admissions"].append(child("descendant", ["root"]))
     pin = snapshot_digest(state)
     if mutation == "remove_gate":
         state["gates"] = []
     elif mutation == "replace_gate":
         state["gates"][0]["generation"] += 1
     elif mutation == "rename_objective":
-        state["entities"][0]["objective_refs"] = ["unrelated"]
+        state["admissions"][0]["objective_refs"] = ["unrelated"]
     elif mutation == "erase_ancestry":
-        state["entities"][1]["parent_refs"] = []
+        state["admissions"][1]["parent_refs"] = []
     else:
-        state["revision"] += 1
+        state["snapshot_generation"] += 1
     assert inspect(state, "descendant", pin=pin).disposition == "BLOCKED_INVALID_STATE"
 
 
@@ -167,7 +177,7 @@ def test_fresh_worker_equivalence_and_inputs_unchanged(tmp_path):
     assert state == before
 
 
-@pytest.mark.parametrize("field", ["gates", "entities", "source_refs", "revision", "schema_version"])
+@pytest.mark.parametrize("field", ["gates", "admissions", "source_refs", "snapshot_generation", "schema_version"])
 @pytest.mark.parametrize("value", [None, "", {}, False])
 def test_malformed_snapshot_fails_closed(field, value):
     state = machine_state()
@@ -204,7 +214,7 @@ def test_snapshot_cannot_omit_a_required_blocked_action(action):
 def test_graph_inconsistency_including_disconnected_records_blocks(defect):
     state = machine_state()
     disconnected = child("disconnected", [])
-    state["entities"].append(disconnected)
+    state["admissions"].append(disconnected)
     if defect == "cycle":
         disconnected["parent_refs"] = ["disconnected"]
     elif defect == "missing_parent":
@@ -212,15 +222,15 @@ def test_graph_inconsistency_including_disconnected_records_blocks(defect):
     elif defect == "missing_gate":
         disconnected["governance_gate_refs"] = ["absent"]
     elif defect == "duplicate_node":
-        state["entities"].append(deepcopy(disconnected))
+        state["admissions"].append(deepcopy(disconnected))
     else:
         state["gates"].append(deepcopy(state["gates"][0]))
     assert inspect(state).disposition == "BLOCKED_INVALID_STATE"
 
 
 @pytest.mark.parametrize("proposal", [None, {}, {"entity_id": "root", "action": "execute"},
-    {"entity_id": "unknown", "action": "claim"}, {"entity_id": "root", "action": []},
-    {"entity_id": "root", "action": "claim", "released": True}])
+    {"entity_id": "unknown", "action": "repo_write"}, {"entity_id": "root", "action": []},
+    {"entity_id": "root", "action": "repo_write", "released": True}])
 def test_invalid_proposal_cannot_grant_authority(proposal):
     state = machine_state()
     assert evaluate(state, proposal, trusted_current_digest=snapshot_digest(state)).disposition == "BLOCKED_INVALID_STATE"
@@ -228,11 +238,11 @@ def test_invalid_proposal_cannot_grant_authority(proposal):
 
 def test_missing_machine_authority_is_blocked():
     assert evaluate(None, {}, trusted_current_digest=None).disposition == "BLOCKED_INVALID_STATE"
-    assert evaluate(machine_state(), {"entity_id": "root", "action": "claim"},
+    assert evaluate(machine_state(), {"entity_id": "root", "action": "repo_write"},
                     trusted_current_digest=None).disposition == "BLOCKED_INVALID_STATE"
 
 
-@pytest.mark.parametrize("action", ["read", "static_analysis", "specification", "test_design"])
+@pytest.mark.parametrize("action", ["static_read", "test_only", "docs_only", "schema_spec_write"])
 def test_nongated_action_is_not_an_execution_authorization(action):
     result = inspect(machine_state(), action=action)
     assert result.disposition == "NO_MATCHING_BLOCK_NOT_AUTHORIZATION"
@@ -243,7 +253,7 @@ def test_nongated_action_is_not_an_execution_authorization(action):
 
 def test_unrelated_scope_cannot_claim_external_enforcement():
     state = machine_state()
-    state["entities"].append(child("unrelated", []))
+    state["admissions"].append(child("unrelated", []))
     result = inspect(state, "unrelated")
     assert result.disposition == "NO_MATCHING_BLOCK_NOT_AUTHORIZATION"
     assert result.effective_active_gates == ()

--- a/elysia_collective_seed/autopilot/contracts/test_issue_33_scope_inheritance.py
+++ b/elysia_collective_seed/autopilot/contracts/test_issue_33_scope_inheritance.py
@@ -24,7 +24,7 @@ def issue_33_state():
     return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
 
 
-def decide(state, entity, action="semantic_write", checkpoint=None):
+def decide(state, entity, action="semantic_code_write", checkpoint=None):
     return evaluate(
         state,
         {"entity_id": entity, "action": action},
@@ -43,14 +43,14 @@ def assert_gated(result):
 def test_issue_33_fixture_is_valid_and_records_exact_preserved_lineage():
     state = issue_33_state()
     VALIDATOR.validate(state)
-    entities = {entity["entity_id"]: entity for entity in state["entities"]}
-    assert entities["detached-4ff2dc92"]["lineage_refs"] == [
+    entities = {entity["entity_id"]: entity for entity in state["admissions"]}
+    assert entities["detached-4ff2dc92"]["repository_lineage_refs"] == [
         "commit:4ff2dc92dd7d9bc393225bce35de9239a9cad6a5"
     ]
-    assert entities["cursor-side-branch"]["lineage_refs"] == [
+    assert entities["cursor-side-branch"]["repository_lineage_refs"] == [
         "branch:cursor/autopilot-003-issue23-restack-cwa"
     ]
-    assert entities["product-7374820"]["lineage_refs"] == [
+    assert entities["product-7374820"]["repository_lineage_refs"] == [
         "commit:7374820642fad52a6264c86df8632c3a630df592"
     ]
 
@@ -100,18 +100,18 @@ def test_external_writer_is_blocked_normatively_but_explicitly_not_enforced(tran
 
 def test_friendly_self_declared_labels_do_not_erase_admitted_parent_scope():
     state = issue_33_state()
-    product = next(e for e in state["entities"] if e["entity_id"] == "product-7374820")
+    product = next(e for e in state["admissions"] if e["entity_id"] == "product-7374820")
     product["objective_refs"] = ["objective:documentation-only"]
-    product["lineage_refs"] = ["branch:totally-new-candidate"]
+    product["repository_lineage_refs"] = ["branch:totally-new-candidate"]
     product["governance_gate_refs"] = []
     assert_gated(decide(state, "product-7374820"))
 
 
 @pytest.mark.parametrize("mutation", [
-    lambda state: state["entities"].remove(next(e for e in state["entities"] if e["entity_id"] == "detached-4ff2dc92")),
-    lambda state: next(e for e in state["entities"] if e["entity_id"] == "product-7374820").update(parent_refs=[]),
-    lambda state: next(e for e in state["entities"] if e["entity_id"] == "product-7374820").update(parent_refs=["unknown"]),
-    lambda state: next(e for e in state["entities"] if e["entity_id"] == "product-7374820").update(objective_refs=[]),
+    lambda state: state["admissions"].remove(next(e for e in state["admissions"] if e["entity_id"] == "detached-4ff2dc92")),
+    lambda state: next(e for e in state["admissions"] if e["entity_id"] == "product-7374820").update(parent_refs=[]),
+    lambda state: next(e for e in state["admissions"] if e["entity_id"] == "product-7374820").update(parent_refs=["unknown"]),
+    lambda state: next(e for e in state["admissions"] if e["entity_id"] == "product-7374820").update(objective_refs=[]),
 ])
 def test_missing_or_ambiguous_admission_state_fails_closed(mutation):
     state = issue_33_state()
@@ -141,15 +141,23 @@ def test_even_exact_shaped_release_remains_unavailable_and_gate_effective():
 
 def test_no_matching_block_is_explicitly_not_authorization():
     state = issue_33_state()
-    state["entities"].append({
+    state["admissions"].append({
         "entity_id": "unrelated-static-review",
+        "entity_kind": "task",
         "ancestry_kind": "root",
         "parent_refs": [],
         "objective_refs": ["github:MsElysia/Elysia:issue:999"],
-        "lineage_refs": ["branch:unrelated"],
+        "repository_lineage_refs": ["branch:unrelated"],
+        "governance_lineage_refs": ["governance:unrelated"],
+        "action_classes": ["static_read"],
+        "admission_generation": 1,
+        "admitted_by": {"authority_id": "fixture:trusted-control-plane", "authority_generation": 1},
+        "admission_source": ["fixture:source"],
+        "admission_evidence": ["fixture:evidence"],
+        "admitted_at": "2026-09-11T00:00:00Z",
         "governance_gate_refs": [],
     })
-    result = decide(state, "unrelated-static-review", "static_analysis")
+    result = decide(state, "unrelated-static-review", "static_read")
     assert result.disposition == "NO_MATCHING_BLOCK_NOT_AUTHORIZATION"
     assert result.effective_active_gates == ()
     assert result.external_write_enforcement == "NOT_ENFORCED"

--- a/elysia_collective_seed/autopilot/handoffs/GOVERNANCE-V2-ADMISSION-HANDOFF.md
+++ b/elysia_collective_seed/autopilot/handoffs/GOVERNANCE-V2-ADMISSION-HANDOFF.md
@@ -105,3 +105,95 @@ Independent falsification, then architecture review. If both pass, preserve
 reports on a separate evidence branch and open a stacked draft PR. A later task
 may design the transactional storage/admission interface but must not claim Git
 or human-auth enforcement without separately authorized implementation/evidence.
+
+## TWO-UNIVERSES FINDING
+
+Independent Cursor reconnaissance supplied by the user on 2026-09-12 identifies
+a split between governance-oriented tips containing TaskLedger / Issue-33
+constructs and operational/runtime lineages containing actual mutation paths.
+This addendum incorporates that reconnaissance without repeating it.
+
+GOVERNANCE UNIVERSE: schema, checkpoint evaluator, trusted admission contracts,
+gate inheritance and tests. OPERATIONAL UNIVERSE: mutation/execution paths, queues,
+repo adapters, Guardian cycles, local/external Git writes. Governance existing
+somewhere in Git history does not protect runtime effects.
+
+> No semantic or durable mutation path may infer authority merely because governance state exists elsewhere. The authoritative mutation boundary must consume a trusted admitted record and current effective gate state before mutation.
+
+Passing governance tests alone does not establish this property in production.
+
+## OPERATIONAL MUTATION SURFACES
+
+| Cursor-identified surface | Current classification |
+| --- | --- |
+| `mutation_engine._direct_apply_mutation` | `NOT_ENFORCED` |
+| `implementer/repo_adapter` | `NOT_ENFORCED` |
+| `self_task_queue` | `NOT_ENFORCED` |
+| `guardian_cursor_cycle` | `NOT_ENFORCED` |
+
+No direct enforcement evidence is supplied for these paths; none is assumed to
+consult governance. The [v2 contract](../contracts/GOVERNANCE_V2_ADMISSION.md#operational-mutation-surfaces-and-required-admission-bindings)
+specifies each surface's required entity identity, explicit root/derived status,
+ancestry, governance lineage, objective, action class, applicable gate generation,
+trusted snapshot/generation and required human-release evidence. These future
+bindings do not change any current enforcement classification.
+
+## CURRENT CROSS-UNIVERSE ENFORCEMENT
+
+`NOT_IMPLEMENTED`
+
+The contract now specifies cross-universe acceptance scenarios: a gated objective
+on governance lineage G, a worker mutation attempt on operational lineage O with
+no governance import or authoritative bridge, and `NOT_ENFORCED` as the expected
+path classification. Operational output, even passing tests, remains unauthorized
+evidence. The scenarios also cover import-only wiring, detached/renamed work,
+direct adapter calls, queue/cycle retries, stale state and transactional races.
+They are specification scenarios, not executed integration tests or proof that
+runtime attempts are blocked.
+
+## REQUIRED GOVERNANCE→RUNTIME BRIDGE
+
+Future requirements: one authoritative admission format; one trusted current gate
+snapshot; objective/action classification before effects; complete ancestry and
+governance-lineage inheritance; fail-closed unknown classification; atomic check
+plus mutation or equivalent transactional protection; no worker-controlled roots;
+no branch-name or detached-SHA escape; no direct adapter or queue/cycle bypass;
+restart-safe trusted state; generation rollback protection; authenticated,
+generation-scoped human releases when required; and authoritative output receipts.
+The [normative bridge requirements](../contracts/GOVERNANCE_V2_ADMISSION.md#required-governance-to-runtime-bridge-future-not-implemented)
+define the obligations. No production bridge is implemented or authorized here.
+
+## FIRST FUTURE MUTATION BOUNDARY TO INTEGRATE
+
+Recommend `mutation_engine._direct_apply_mutation` as the first bounded candidate:
+the directly identified apply operation offers a small place to bind one concrete
+mutation effect to an admitted entity and current gate generation. This is a
+design recommendation based on the supplied surface, not a verified claim that
+all writes converge there. A separately authorized integration task must first
+establish its actual write/transaction boundary and caller coverage, then enforce
+and test that bounded effect. Adapter, queue, cycle and external-write routes
+remain `NOT_ENFORCED` unless separately covered and evidenced. Do not implement
+this recommendation without separate authority.
+
+## CURSOR FINDING INCORPORATION RECORD
+
+Task: Governance Schema v2 / Trusted Admission Contract, Cursor finding addendum.
+Worker: Codex. State: specification incorporated; production bridge pending
+separate authority. Issue #23: `GATED — NO SEMANTIC WORK AUTHORIZED`.
+
+Read: repository `AGENTS.md`, existing v2 specification and this handoff; supplied
+Cursor findings. Changed: only this handoff and `GOVERNANCE_V2_ADMISSION.md`.
+Existing admission/reference/schema working-tree changes belong to other ongoing
+work and are outside this addendum. No operational source was changed or invoked.
+
+Validation: reviewed all nine admission bindings for every listed surface, all
+requested bridge properties, and the cross-universe scenario matrix; ran scoped
+`git diff --check`. No executable tests added or run for this documentation-only
+addendum. Earlier test counts above are historical and do not validate runtime
+enforcement. Changes are uncommitted on `codex/governance-v2-trusted-admission`.
+
+Uncertainty/risk: supplied reconnaissance does not establish a universal write
+choke point or authenticated human release mechanism. Next bounded task remains
+independent contract review; any runtime integration needs separate authority
+and direct boundary evidence. No merge, publication, release or Issue #23 semantic
+work is authorized by this record.

--- a/elysia_collective_seed/autopilot/handoffs/GOVERNANCE-V2-ADMISSION-HANDOFF.md
+++ b/elysia_collective_seed/autopilot/handoffs/GOVERNANCE-V2-ADMISSION-HANDOFF.md
@@ -1,0 +1,107 @@
+# GOVERNANCE V2 ADMISSION HANDOFF
+
+## BASE SHA
+
+`9ad2d941269650b231d3f3e4f5327266a66f9cb1` (draft PR #35 product).
+
+## CANDIDATE SHA
+
+Recorded after commit and in separate exact-candidate verification evidence.
+Branch: `codex/governance-v2-trusted-admission`.
+
+## SCHEMA VERSION
+
+`2`. Only exact integer version 2 is a valid current snapshot. V1 is accepted
+solely by the explicit migration reference function. Missing, boolean, string,
+older, and forward versions fail closed.
+
+## BREAKING CHANGE
+
+V2 replaces `revision/entities` with `snapshot_generation/admissions`, separates
+repository from governance lineage, adds an authority registry and provenance,
+and binds authoritative action classes. It resolves PR #35's improper breaking
+mutation of v1. Existing v1 data cannot be consumed directly as v2.
+
+## V1 → V2 MIGRATION
+
+Migration requires a pinned v1 digest, explicit manifest, separately configured
+trusted migration authority, strictly increasing generation, exactly one decision
+per old entity, explicit root evidence, exact parent/objective/gate preservation,
+repository-lineage preservation, nonempty governance lineage, and durable source
+and manifest digests. Empty parents never infer root. Gate actions are mapped
+conservatively and expanded to every consequential v2 action. Released assertions
+remain ineffective. The reference is pure and deterministic; production
+transaction/persistence is not implemented.
+
+## ROOT ADMISSION MODEL
+
+Root is privileged classification by a registered trusted control-plane authority
+at an exact generation with source/evidence/time. A new name, branch, session,
+provider, detached SHA, or empty parent list grants nothing. Derived admissions
+require existing parents. Authority strings are normative data, not authentication.
+
+## OBJECTIVE ADMISSION MODEL
+
+Objective references live in trusted admission records and union through all
+parents. Workers cannot replace them in proposal metadata. Expansion/reclassification
+requires a new trusted admission with evidence; ambiguity remains blocked.
+
+## ACTION ADMISSION MODEL
+
+Stored classes distinguish static read, tests, docs, schema/spec, semantic code,
+repo write, integration, merge, deploy, external write, permissions and private
+data. The proposed authoritative action must exist in the admission. Descriptive
+worker action labels are ignored and cannot downgrade semantic code to tests/docs.
+
+## REPOSITORY ANCESTRY MODEL
+
+Repository lineage represents independently derived Git/control-plane facts:
+parents, branches, SHAs, PRs, detached rebinds and merge parents. This reference
+model consumes those facts; it does not retrieve or authenticate them.
+
+## GOVERNANCE LINEAGE MODEL
+
+Governance lineage carries semantic descent across cherry-picks, ports, restacks,
+recreated patches and preservation branches where Git ancestry alone is
+insufficient. Repository and governance lineages union transitively and either
+can match a gate.
+
+## FAIL-CLOSED CONDITIONS
+
+Unsupported versions, stale pins, generation rollback, unknown/duplicate authority,
+incomplete/conflicting admissions, unknown/missing parents, ambiguous roots,
+lost ancestry/objectives/lineage/gates, unadmitted action, malformed data, and
+unvalidated releases block. No-match remains explicitly non-authorizing.
+
+## TEST RESULTS
+
+Implementer: **376 passed** (163 governance contract and 213 inherited tests),
+Python 3.13.15, pytest 9.1.1, jsonschema 4.26.0. Contract compileall, every JSON
+parse, and `git diff --check` passed. No Guardian/runtime/provider code activated.
+
+## VEGA VERDICT
+
+Pending fresh breaker on exact committed candidate.
+
+## ARCHITECTURE VERDICT
+
+Pending separate reviewer after Vega PASS.
+
+## PRODUCTION ENFORCEMENT STATUS
+
+`NOT_IMPLEMENTED`
+
+## HUMAN TRUST ANCHOR STATUS
+
+`UNRESOLVED`
+
+## ISSUE #23 STATUS
+
+`GATED — NO SEMANTIC WORK AUTHORIZED`
+
+## NEXT BOUNDED TASK
+
+Independent falsification, then architecture review. If both pass, preserve
+reports on a separate evidence branch and open a stacked draft PR. A later task
+may design the transactional storage/admission interface but must not claim Git
+or human-auth enforcement without separately authorized implementation/evidence.


### PR DESCRIPTION
## Problem and resulting behavior

The draft governance snapshot needed an explicit breaking v2 boundary: trusted root/derived admission, authoritative objective and action classification, separate repository and governance lineage, and a deterministic v1 migration that cannot turn worker metadata into authority.

This stacked specification-and-test change introduces schema v2, preserves and validates the exact v1 schema, requires trusted admission authority generations, migrates only from pinned validated v1 state, and fails closed on malformed, stale, ambiguous, or semantically invalid inputs. It also documents the governance/operational-universe split and the future atomic mutation-boundary obligations.

## Verification

- Candidate: `7b076548751e72879d0632c1ec687e087e43a7b8`
- Base: `9ad2d941269650b231d3f3e4f5327266a66f9cb1` (draft PR #35 product)
- Candidate/inherited suite: 414 passed
- Focused contract suite: 201 passed
- Independent Vega breaker corpus: 151 passed; exact-candidate verdict PASS
- Independent architecture verdict: READY_FOR_INTEGRATION_REVIEW; no in-scope blockers
- Evidence commit: `09f5b18193813594186601eda987d644ffd5706a` on `codex/governance-v2-trusted-admission-evidence`
- compileall, 65 JSON parses, v1 schema object identity, diff-check, detached exact-SHA, and clean-worktree checks passed

## Scope and limits

This is `SPECIFICATION_AND_TEST_ONLY`. Production/cross-universe enforcement is `NOT_IMPLEMENTED`; external writes are `NOT_ENFORCED`; the human trust anchor is `UNRESOLVED`; release validation is `UNAVAILABLE`. It does not activate runtime paths or authorize integration, merge, deployment, or release. Issue #23 remains gated. PR #34 remains preserved unauthorized evidence.

This PR is intentionally stacked on `codex/governance-33-scope-inheritance-regression` for review of the v2 delta after PR #35.