### PR TITLE
fix(governance): validate generations before rollback compare

### DIFF
--- a/breaker_tests/test_vega_v2_generation.py
+++ b/breaker_tests/test_vega_v2_generation.py
@@ -1,0 +1,37 @@
+"""Independent regression for the public v2 admission decision boundary."""
+import json
+
+import pytest
+
+from elysia_collective_seed.autopilot.contracts.admission import evaluate_admitted
+from elysia_collective_seed.autopilot.contracts.checkpoint_reference import snapshot_digest
+from elysia_collective_seed.autopilot.contracts.test_admission_v2 import migrate
+
+
+@pytest.mark.parametrize("generation", [None, "8", [], {}])
+def test_malformed_reopened_generation_returns_blocked_decision(generation):
+    snapshot = migrate()
+    snapshot["snapshot_generation"] = generation
+    snapshot = json.loads(json.dumps(snapshot))
+    result = evaluate_admitted(
+        snapshot, "child", "semantic_code_write",
+        trusted_current_digest=snapshot_digest(snapshot), minimum_generation=8,
+    )
+    assert result.disposition == "BLOCKED_INVALID_STATE"
+    assert result.release_validation == "UNAVAILABLE"
+    assert result.external_write_enforcement == "NOT_ENFORCED"
+
+
+@pytest.mark.parametrize("minimum, expected", [
+    (8, "BLOCKED_PENDING_HUMAN_RELEASE"), (9, "BLOCKED_INVALID_STATE"),
+])
+def test_valid_reopened_generation_preserves_gate_and_rollback(minimum, expected):
+    snapshot = json.loads(json.dumps(migrate()))
+    result = evaluate_admitted(
+        snapshot, "child", "semantic_code_write",
+        trusted_current_digest=snapshot_digest(snapshot), minimum_generation=minimum,
+        worker_proposal={"action": "docs_only", "status": "allowed"},
+    )
+    assert result.disposition == expected
+    assert result.release_validation == "UNAVAILABLE"
+    assert result.external_write_enforcement == "NOT_ENFORCED"

--- a/elysia_collective_seed/autopilot/contracts/admission.py
+++ b/elysia_collective_seed/autopilot/contracts/admission.py
@@ -37,17 +37,33 @@ def _digest(value) -> str:
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
+def _exact_generation(value, *, field: str) -> int:
+    """Require an exact non-boolean integer in the v2 generation range.
+
+    JSON bools are rejected: ``type(True) is int`` is false, but relying on
+    ``isinstance(..., int)`` would incorrectly accept booleans. Strings, floats,
+    null, containers, and other malformed values are not coerced.
+    """
+    if type(value) is not int or value < 1:
+        raise AdmissionError(f"invalid_{field}")
+    return value
+
+
 def validate_snapshot_version(snapshot, *, minimum_generation=None) -> None:
     """Reject unsupported versions and generation rollback before evaluation."""
     if (not isinstance(snapshot, dict)
             or type(snapshot.get("schema_version")) is not int
             or snapshot.get("schema_version") != 2):
         raise AdmissionError("unsupported_schema_version")
-    if minimum_generation is not None and (
-        type(minimum_generation) is not int
-        or snapshot.get("snapshot_generation", 0) < minimum_generation
-    ):
-        raise AdmissionError("snapshot_generation_rollback")
+    if minimum_generation is not None:
+        generation = _exact_generation(
+            snapshot.get("snapshot_generation"), field="snapshot_generation",
+        )
+        minimum = _exact_generation(
+            minimum_generation, field="minimum_generation",
+        )
+        if generation < minimum:
+            raise AdmissionError("snapshot_generation_rollback")
     if not VALIDATOR.is_valid(snapshot):
         raise AdmissionError("invalid_v2_snapshot")
 

--- a/elysia_collective_seed/autopilot/contracts/test_admission_v2_adversarial.py
+++ b/elysia_collective_seed/autopilot/contracts/test_admission_v2_adversarial.py
@@ -4,6 +4,7 @@ These assertions state the fail-closed behavior promised by
 GOVERNANCE_V2_ADMISSION.md. They live outside the candidate worktree.
 """
 from copy import deepcopy
+import json
 
 import pytest
 
@@ -351,3 +352,32 @@ def test_malformed_minimum_generation_fails_closed(bad):
             source, manifest(source), trusted_source_digest=snapshot_digest(source),
             trusted_authorities=[AUTHORITY], minimum_target_generation=bad,
         )
+
+
+@pytest.mark.parametrize("generation", [None, "1", [], {}, True, False, -1, 1.5])
+def test_malformed_snapshot_generation_fails_closed_at_public_boundary(generation):
+    """Public evaluate_admitted must not raise on malformed generation values."""
+    snapshot = migrate(legacy_v1())
+    snapshot["snapshot_generation"] = generation
+    if generation not in (True, False):
+        snapshot = json.loads(json.dumps(snapshot))
+    result = evaluate_admitted(
+        snapshot, "child", "semantic_code_write",
+        trusted_current_digest=snapshot_digest(snapshot), minimum_generation=1,
+    )
+    assert result.disposition == "BLOCKED_INVALID_STATE"
+    assert result.release_validation == "UNAVAILABLE"
+    assert result.external_write_enforcement == "NOT_ENFORCED"
+
+
+@pytest.mark.parametrize("minimum", ["1", [], {}, True, False, -1, 1.5, 0])
+def test_malformed_minimum_generation_at_validate_boundary(minimum):
+    snapshot = migrate(legacy_v1())
+    with pytest.raises(AdmissionError, match="invalid_minimum_generation"):
+        validate_snapshot_version(snapshot, minimum_generation=minimum)
+
+
+def test_equal_and_increasing_generation_remain_valid():
+    snapshot = json.loads(json.dumps(migrate(legacy_v1())))
+    validate_snapshot_version(snapshot, minimum_generation=snapshot["snapshot_generation"])
+    validate_snapshot_version(snapshot, minimum_generation=1)

--- a/elysia_collective_seed/autopilot/handoffs/GOVERNANCE-V2-GENERATION-BOUNDARY-REPAIR-HANDOFF.md
+++ b/elysia_collective_seed/autopilot/handoffs/GOVERNANCE-V2-GENERATION-BOUNDARY-REPAIR-HANDOFF.md
@@ -1,0 +1,118 @@
+# GOVERNANCE V2 GENERATION-BOUNDARY REPAIR HANDOFF
+
+## BASE SHA
+
+`e4051fc8464796b7a65d2eb3456f926a9bf4a8e3`
+
+## NEW PRODUCT SHA
+
+`fe7dc8c365b948f5d3ca6430e764e4f938cdd1ed`
+
+Branch: `cursor/governance-v2-generation-boundary-repair-1799`
+Codex product branch `codex/governance-v2-effect-binding-repair` was not mutated.
+
+## DEFECT REPRODUCED
+
+On exact base `e4051fc...`, preserved breaker `breaker_tests/test_vega_v2_generation.py` failed **4 / 6**:
+
+| Case | Actual |
+| --- | --- |
+| `snapshot_generation=null` | uncaught `TypeError` |
+| `snapshot_generation="8"` | uncaught `TypeError` |
+| `snapshot_generation=[]` | uncaught `TypeError` |
+| `snapshot_generation={}` | uncaught `TypeError` |
+
+Valid equal-generation / rollback cases already passed. Failure site: `validate_snapshot_version` compared `snapshot.get("snapshot_generation", 0) < minimum_generation` before proving both values were exact integers. `evaluate_admitted` only caught `AdmissionError`, so `TypeError` escaped the public boundary.
+
+## ROOT CAUSE
+
+Rollback comparison ran before exact integer validation of `snapshot_generation`. Malformed JSON values therefore raised during ordering instead of returning `BLOCKED_INVALID_STATE`.
+
+## FILES CHANGED
+
+1. `elysia_collective_seed/autopilot/contracts/admission.py` — shared `_exact_generation` + pre-compare validation
+2. `elysia_collective_seed/autopilot/contracts/test_admission_v2_adversarial.py` — bool/negative/float/zero coverage
+3. `breaker_tests/test_vega_v2_generation.py` — restored preserved breaker unchanged in assertions
+
+## MALFORMED GENERATION CASES
+
+Fail-closed (`AdmissionError` / `BLOCKED_INVALID_STATE`), no raise, no coerce:
+
+- snapshot: `null`, `"1"`/`"8"`, `[]`, `{}`, `true`, `false`, `-1`, `1.5`, `0`, `3.0`
+- minimum: same family plus `0`
+- no `"8"→8` or `8.0→8` or `True→1`
+
+## VALID GENERATION CASES
+
+Preserved:
+
+- exact int generation `>= 1`
+- equal generation vs minimum
+- lower valid minimum (increasing/non-rollback)
+- rollback (`generation < minimum` → `snapshot_generation_rollback`)
+
+Schema range remains `minimum: 1` (zero invalid).
+
+## PRESERVED BREAKER RESULT
+
+After repair: **6 passed** (`breaker_tests/test_vega_v2_generation.py`).
+
+## FULL TEST COUNTS
+
+Fresh runs at `fe7dc8c365b948f5d3ca6430e764e4f938cdd1ed`:
+
+| Suite | Result |
+| --- | --- |
+| Preserved breaker | **6 passed** |
+| Admission + adversarial (+ new cases) | **81 passed** |
+| Full governance contracts | **291 passed** |
+| Issue #33 | **22 passed** |
+| Blueprint repair | **32 passed** |
+| Effect-binding | **41 passed** |
+| Aggregate (contracts + autopilot + focused regressions + breaker) | **510 passed** |
+| compileall / AST (changed Python) | pass |
+| Schema meta (3) | pass |
+| JSON parse | 66 files; 1 pre-existing BOM outside delta |
+| `git diff --check` | pass |
+
+## VEGA VERDICT
+
+**PASS** — bound to `fe7dc8c365b948f5d3ca6430e764e4f938cdd1ed`
+
+Independent worktree campaign: 54 probes, 0 fails (malformed/bool/negative/fractional/zero/rollback/no-coercion through `evaluate_admitted` + `validate_snapshot_version`).
+
+## ARCHITECTURE VERDICT
+
+**READY_FOR_INTEGRATION_REVIEW**
+
+Validation precedes comparison; no permissive coercion; fail-closed path unchanged; effect-binding untouched; production enforcement still unimplemented.
+
+## EXACT-HEAD CI STATUS
+
+`CI_REACHABILITY_BLOCKED_BY_ISSUE_39`
+
+Evidence: `.github/workflows/elysia-autopilot-ci.yml` push filters are `elysia-collective-*`, `autopilot-*`, `codex/governance-checkpoint-contract` only; PR bases are `main`, `elysia-collective-*`, `autopilot-*`, `codex/remote-fix-*`. Exact head `fe7dc8c365b948f5d3ca6430e764e4f938cdd1ed` has `total_count: 0` check runs. Issue #39 remains open. CI workflow was not modified.
+
+## EFFECT-BINDING STATUS
+
+`UNCHANGED`
+
+## PRODUCTION ENFORCEMENT
+
+`NOT_IMPLEMENTED`
+
+## CROSS-UNIVERSE ENFORCEMENT
+
+`NOT_IMPLEMENTED`
+
+## HUMAN TRUST ANCHOR
+
+`UNRESOLVED`
+
+## ISSUE #23
+
+`GATED — NO SEMANTIC WORK AUTHORIZED`
+
+## NEXT STATUS
+
+`READY_FOR_FOCUSED_FINAL_RED_TEAM`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Minimal governance-contract repair on exact base `e4051fc8464796b7a65d2eb3456f926a9bf4a8e3`.

- **Product repair SHA:** `fe7dc8c365b948f5d3ca6430e764e4f938cdd1ed`
- Branch tip (includes handoff doc): `6f0b23029908fe56b6a5fddc142a2d1bfb87eb6d`
- Restores/preserves `breaker_tests/test_vega_v2_generation.py` (was 4 failing TypeErrors on base; now 6 passed)
- Shared boundary now validates exact non-boolean integer `snapshot_generation` and `minimum_generation` **before** rollback comparison
- No coercion of strings/floats/bools; fail-closed `BLOCKED_INVALID_STATE`
- Effect-binding design unchanged; Codex product branch not mutated

## Verification
- Preserved breaker: 6 passed
- Governance contracts: 291 passed
- Aggregate required suite + breaker: 510 passed
- Independent Vega: **PASS** on `fe7dc8c...`
- Architecture: **READY_FOR_INTEGRATION_REVIEW**
- Exact-head CI: **CI_REACHABILITY_BLOCKED_BY_ISSUE_39** (workflow filters exclude this branch/base; workflow not changed)

## Non-goals
No production enforcement, no Issue #23 work, no CI filter expansion.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-601c2ff0-42e5-4929-9060-55aa51c31799?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-601c2ff0-42e5-4929-9060-55aa51c31799&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

